### PR TITLE
feat: Composable nested layouts

### DIFF
--- a/.changeset/warm-masks-think.md
+++ b/.changeset/warm-masks-think.md
@@ -1,0 +1,6 @@
+---
+"@squide/react-router": minor
+"@squide/core": minor
+---
+
+Added a new composable nested layouts feature

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Jest: current file",
+        "program": "${workspaceFolder}/node_modules/.bin/jest",
+        "args": ["${fileBasenameNoExtension}", "--config", "jest.config.ts"],
+        "console": "integratedTerminal",
+        "windows": {
+          "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+        }
+      }
+    ]
+  }

--- a/docs/getting-started/create-host.md
+++ b/docs/getting-started/create-host.md
@@ -36,12 +36,17 @@ First, create the following files:
 
 ```
 host
+├── public
+├──── index.html
 ├── src
 ├──── App.tsx
 ├──── RootLayout.tsx
 ├──── Home.tsx
 ├──── bootstrap.tsx
 ├──── index.ts
+├── .browserslistrc
+├── swc.dev.js
+├── swc.build.js
 ├── webpack.dev.js
 ├── webpack.build.js
 ```
@@ -219,9 +224,48 @@ export default function RootLayout() {
 
 ## 3. Configure webpack
 
-### development
+!!!info
+`@squide` webpack configuration is built on top of [@workleap/webpack-configs](https://gsoft-inc.github.io/wl-web-configs/webpack/), [@workleap/browserslist-config](https://gsoft-inc.github.io/wl-web-configs/browserslist/) and [@workleap/swc-configs](https://gsoft-inc.github.io/wl-web-configs/swc/). If you are having issues with the configuration of these tools, have a look at their documentation websites.
+!!!
 
-To configure webpack for a federated host application in **development** mode, use the [defineDevHostConfig](/reference/webpack/defineDevHostConfig.md) function:
+### HTML template
+
+First, open the `public/index.html` file created at the beginning of this guide and copy/paste the following [HtmlWebpackPlugin](https://webpack.js.org/plugins/html-webpack-plugin/) template:
+
+```html host/public/index.html
+<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+        <div id="root"></div>
+    </body>
+</html>
+```
+
+### Browserslist
+
+Then, open the `.browserslist` file and copy/paste the following content:
+
+``` host/.browserslistrc
+extends @workleap/browserslist-config
+```
+
+### Development configuration
+
+To configure webpack for a **development** environment, first open the `swc.dev.js` file and copy/paste the following code:
+
+```js host/swc.dev.js
+// @ts-check
+
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
+
+const targets = browserslistToSwc();
+
+export default defineDevConfig(targets);
+```
+
+Then, open the `webpack.dev.js` file and use the [defineDevHostConfig](/reference/webpack/defineDevHostConfig.md) function to configure webpack:
 
 ```js !#6 host/webpack.dev.js
 // @ts-check
@@ -232,9 +276,25 @@ import { swcConfig } from "./swc.dev.js";
 export default defineDevHostConfig(swcConfig, "host", 8080);
 ```
 
-### build
+!!!info
+If you are having issues with the wepack configuration that are not related to module federation, refer to the [@workleap/webpack-configs documentation](https://gsoft-inc.github.io/wl-web-configs/webpack/configure-dev/).
+!!!
 
-To configure webpack for a federated host application in **build** mode, use the [defineBuildHostConfig](/reference/webpack/defineBuildHostConfig.md) function:
+### Build configuration
+
+To configure webpack for a **build** environment, first open the `swc.build.js` file and copy/paste the following code:
+
+```js host/swc.build.js
+// @ts-check
+
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
+
+const targets = browserslistToSwc();
+
+export default defineBuildConfig(targets);
+```
+
+Then, open the `webpack.build.js` file and use the [defineBuildHostConfig](/reference/webpack/defineBuildHostConfig.md) function to configure webpack:
 
 ```js !#6 host/webpack.build.js
 // @ts-check
@@ -244,6 +304,10 @@ import { swcConfig } from "./swc.build.js";
 
 export default defineBuildHostConfig(swcConfig, "host", "http://localhost:8080/");
 ```
+
+!!!info
+If you are having issues with the wepack configuration that are not related to module federation, refer to the [@workleap/webpack-configs documentation](https://gsoft-inc.github.io/wl-web-configs/webpack/configure-build/).
+!!!
 
 ## 4. Try the application :rocket:
 

--- a/docs/getting-started/create-remote-module.md
+++ b/docs/getting-started/create-remote-module.md
@@ -12,9 +12,6 @@ Let's add our first remote module!
 
 Create a new project (we'll refer to ours as `remote-module`), then open a terminal at the root of the new solution and install the following packages:
 
-pnpm add -D @workleap/webpack-configs @workleap/swc-configs webpack webpack-dev-server webpack-cli swc/core @swc/helpers browserslist postcss
-pnpm add @squide/core @squide/react-router @squide/webpack-module-federation react react-dom react-router-dom
-
 +++ pnpm
 ```bash
 pnpm add -D @workleap/webpack-configs @workleap/swc-configs webpack webpack-dev-server webpack-cli @swc/core @swc/helpers browserslist postcss

--- a/docs/getting-started/create-remote-module.md
+++ b/docs/getting-started/create-remote-module.md
@@ -37,9 +37,14 @@ First, create the following files:
 
 ```
 remote-module
+├── public
+├──── index.html
 ├── src
 ├──── register.tsx
 ├──── Page.tsx
+├── .browserslistrc
+├── swc.dev.js
+├── swc.build.js
 ├── webpack.dev.js
 ├── webpack.build.js
 ```
@@ -82,9 +87,48 @@ export default function Page() {
 
 ## 3. Configure webpack
 
-### development
+!!!info
+`@squide` webpack configuration is built on top of [@workleap/webpack-configs](https://gsoft-inc.github.io/wl-web-configs/webpack/), [@workleap/browserslist-config](https://gsoft-inc.github.io/wl-web-configs/browserslist/) and [@workleap/swc-configs](https://gsoft-inc.github.io/wl-web-configs/swc/). If you are having issues with the configuration of these tools, have a look at their documentation websites.
+!!!
 
-To configure webpack for a federated remote module application in **development** mode, use the [defineDevRemoteModuleConfig](/reference/webpack/defineDevRemoteModuleConfig.md) function:
+### HTML template
+
+First, open the `public/index.html` file created at the beginning of this guide and copy/paste the following [HtmlWebpackPlugin](https://webpack.js.org/plugins/html-webpack-plugin/) template:
+
+```html host/public/index.html
+<!DOCTYPE html>
+<html>
+    <head>
+    </head>
+    <body>
+        <div id="root"></div>
+    </body>
+</html>
+```
+
+### Browserslist
+
+Then, open the `.browserslist` file and copy/paste the following content:
+
+``` host/.browserslistrc
+extends @workleap/browserslist-config
+```
+
+### Development configuration
+
+To configure webpack for a **development** environment, first open the `swc.dev.js` file and copy/paste the following code:
+
+```js remote-module/swc.dev.js
+// @ts-check
+
+import { browserslistToSwc, defineDevConfig } from "@workleap/swc-configs";
+
+const targets = browserslistToSwc();
+
+export default defineDevConfig(targets);
+```
+
+Then, open the `webpack.dev.js` file and use the the [defineDevRemoteModuleConfig](/reference/webpack/defineDevRemoteModuleConfig.md) function to configure webpack:
 
 ```js !#6 remote-module/webpack.dev.js
 // @ts-check
@@ -95,9 +139,25 @@ import { swcConfig } from "./swc.dev.js";
 export default defineDevRemoteModuleConfig(swcConfig, "remote1", 8081);
 ```
 
-### build
+!!!info
+If you are having issues with the wepack configuration that are not related to module federation, refer to the [@workleap/webpack-configs documentation](https://gsoft-inc.github.io/wl-web-configs/webpack/configure-dev/).
+!!!
 
-To configure webpack for a federated remote module application in **build** mode, use the [defineBuildRemoteModuleConfig](/reference/webpack/defineBuildRemoteModuleConfig.md) function:
+### Build configuration
+
+To configure webpack for a **build** environment, first open the `swc.build.js` file and copy/paste the following code:
+
+```js remote-module/swc.build.js
+// @ts-check
+
+import { browserslistToSwc, defineBuildConfig } from "@workleap/swc-configs";
+
+const targets = browserslistToSwc();
+
+export default defineBuildConfig(targets);
+```
+
+Then, open the `webpack.build.js` file and use the the [defineBuildRemoteModuleConfig](/reference/webpack/defineBuildRemoteModuleConfig.md) function to configure webpack:
 
 ```js !#6 remote-module/webpack.build.js
 // @ts-check
@@ -107,6 +167,10 @@ import { swcConfig } from "./swc.build.js";
 
 export default defineBuildRemoteModuleConfig(swcConfig, "remote1", "http://localhost:8081/");
 ```
+
+!!!info
+If you are having issues with the wepack configuration that are not related to module federation, refer to the [@workleap/webpack-configs documentation](https://gsoft-inc.github.io/wl-web-configs/webpack/configure-build/).
+!!!
 
 ## 4. Try the application :rocket:
 

--- a/docs/reference/runtime/runtime-class.md
+++ b/docs/reference/runtime/runtime-class.md
@@ -83,10 +83,9 @@ runtime.registerRoutes([
 
 React router [nested routes](https://reactrouter.com/en/main/start/tutorial#nested-routes) enable applications to render nested layouts at various points within the router tree. This is quite helpful for federated applications as it enables composable and decoupled UI.
 
-To fully harness the power of nested routes, this shell allows a route to be registered **under any** previously registered **nested layout route**, even if that route was registered by another module.
+To fully harness the power of nested routes, the `registerRoutes` function allows a route to be registered **under any** previously registered **nested layout route**, even if that route was registered by another module.
 
-When registering a new route, to render the route under a specific nested layout route, specify a `layoutPath` property that matches the nested layout route's `path` property. The only requirement is that the **nested layout route** must has been **registered** to `@squide` **before** the **new child route**.
-
+When registering a new route with the `registerRoutes` function, to render the route under a specific nested layout route, specify a `layoutPath` property that matches the nested layout route's `path` property. The only requirement is that the **nested layout route** must has been **registered** to `@squide` **before** the **new child route**.
 
 ```tsx !#10
 import { lazy } from "react";
@@ -95,11 +94,15 @@ const Page = lazy(() => import("./Page.tsx"));
 
 runtime.registerRoutes([
     {
-        path: "/page-1",
+        path: "/layout/page-1",
         element: <Page />
     }
-], { layoutPath: "/layout-path" });
+], { layoutPath: "/layout" }); // Register the page under the "/layout" nested layout.
 ```
+
+!!!info
+Likewise any other React Router routes, the `path` property of a page rendered under a nested layout must be an absolute path. For example, if a nested layout `path` is `/layout`, the `path` property of a page rendered under that layout route and responding to the `/page-1` url, should be `/layout/page-1`.
+!!!
 
 #### Index routes
 
@@ -132,10 +135,18 @@ const Page = lazy(() => import("./Page.tsx"));
 
 runtime.registerRoutes([
     {
-        path: "/page-2",
+        path: "/page-1/page-2",
         element: <Page />
     }
-], { layoutPath: "/page-1/$index$" });
+], { layoutPath: "/page-1/$index$" }); // Using $index$ to match "index: true"
+```
+
+### Retrieve routes
+
+A federated application routes are accessible from a `Runtime` instance, but keep in mind that the preferred way to retrieve the routes is with the [useRoutes](./useRoutes) hook.
+
+```tsx
+const routes = runtime.routes;
 ```
 
 ### Register navigation items
@@ -280,6 +291,35 @@ runtime.registerNavigationItems([
         }
     }
 ]);
+```
+
+### Register navigation items for a specific menu
+
+By default, every navigation item registered with the `registerNavigationItems` function is registered as part of the `root` navigation menu. To register a navigation item for a different navigation menu, specify a `menuId` property when registering the items.
+
+```tsx !#6
+runtime.registerNavigationItems([
+    {
+        to: "/layout/page-1",
+        label: "Page 1"
+    }
+], { menuId: "my-custom-layout" });
+```
+
+### Retrieve navigation items
+
+A federated application navigation items are accessible from a `Runtime` instance, but keep in mind that the preferred way to retrieve the navigation items is with the [useNavigationItems](./useNavigationItems) hook.
+
+By default, the `getNavigationItems` will return the navigation items for the `root` menu:
+
+```tsx
+const navigationItems = runtime.getNavigationItems();
+```
+
+To retrieve the navigation items for a **specific** navigation menu, provide a `menuId`:
+
+```tsx
+const navigationItems = runtime.getNavigationItems("my-custom-layout");
 ```
 
 ### Use the logger

--- a/docs/reference/runtime/runtime-class.md
+++ b/docs/reference/runtime/runtime-class.md
@@ -77,7 +77,66 @@ runtime.registerRoutes([
 ]);
 ```
 
-[!ref icon="gear" text="Setup the host application to accept hoisted routes"](/reference/routing/useHoistedRoutes.md)
+[!ref text="Setup the host application to accept hoisted routes"](/reference/routing/useHoistedRoutes.md)
+
+### Register routes under a specific nested layout route
+
+React router [nested routes](https://reactrouter.com/en/main/start/tutorial#nested-routes) enable applications to render nested layouts at various points within the router tree. This is quite helpful for federated applications as it enables composable and decoupled UI.
+
+To fully harness the power of nested routes, this shell allows a route to be registered **under any** previously registered **nested layout route**, even if that route was registered by another module.
+
+When registering a new route, to render the route under a specific nested layout route, specify a `layoutPath` property that matches the nested layout route's `path` property. The only requirement is that the **nested layout route** must has been **registered** to `@squide` **before** the **new child route**.
+
+
+```tsx !#10
+import { lazy } from "react";
+
+const Page = lazy(() => import("./Page.tsx"));
+
+runtime.registerRoutes([
+    {
+        path: "/page-1",
+        element: <Page />
+    }
+], { layoutPath: "/layout-path" });
+```
+
+#### Index routes
+
+Although nested layout routes that serves as indexes (e.g. `{ index: true, element: <Layout /> }`) are not very common, `@squide` still supports this scenario. To register a route **under an index route**, set the `layoutPath` property as the concatenation of the index route's parent path and `/$index$`. 
+
+```tsx !#8,12 host/src/register.tsx
+import { lazy } from "react";
+
+const Page = lazy(() => import("./Page.tsx"));
+const Layout = lazy(() => import("./Layout.tsx"));
+
+runtime.registerRoutes([
+    {
+        path: "/page-1",
+        element: <Page />,
+        children: [
+            {
+                index: true,
+                element: <Layout />
+            }
+        ]
+    }
+]);
+```
+
+```tsx !#10 remote-module/src/register.tsx
+import { lazy } from "react";
+
+const Page = lazy(() => import("./Page.tsx"));
+
+runtime.registerRoutes([
+    {
+        path: "/page-2",
+        element: <Page />
+    }
+], { layoutPath: "/page-1/$index$" });
+```
 
 ### Register navigation items
 
@@ -103,7 +162,7 @@ runtime.registerNavigationItems([
 ]);
 ```
 
-[!ref icon="gear" text="Setup the host application to render navigation items"](/reference/routing/useRenderedNavigationItems.md)
+[!ref text="Setup the host application to render navigation items"](/reference/routing/useRenderedNavigationItems.md)
 
 ### Register nested navigation items
 

--- a/docs/reference/runtime/useNavigationItems.md
+++ b/docs/reference/runtime/useNavigationItems.md
@@ -14,7 +14,7 @@ const navigationItems = useNavigationItems()
 
 ### Parameters
 
-None
+- `menuId`: An optional id to retrieve the navigation menu for a specific menu.
 
 ### Returns
 
@@ -22,8 +22,18 @@ An array of `NavigationItem`.
 
 ## Usage
 
+### Retrieve the items for the `root` menu
+
 ```ts
 import { useNavigationItems } from "@squide/react-router";
 
 const items = useNavigationItems();
+```
+
+### Retrieve the items for a specific menu
+
+```ts
+import { useNavigationItems } from "@squide/react-router";
+
+const items = useNavigationItems("my-custom-menu");
 ```

--- a/packages/core/src/runtime/abstractRuntime.ts
+++ b/packages/core/src/runtime/abstractRuntime.ts
@@ -15,10 +15,10 @@ export interface RegisterRoutesOptions {
 }
 
 export interface RegisterNavigationItemsOptions {
-    menuPath?: string;
+    menuId?: string;
 }
 
-export const RootMenuPath = "/";
+export const RootMenuId = "root";
 
 export abstract class AbstractRuntime<TRoute = unknown, TNavigationItem = unknown> {
     protected readonly _logger: RuntimeLogger;

--- a/packages/core/src/runtime/abstractRuntime.ts
+++ b/packages/core/src/runtime/abstractRuntime.ts
@@ -10,6 +10,16 @@ export interface RuntimeOptions {
     sessionAccessor?: SessionAccessorFunction;
 }
 
+export interface RegisterRoutesOptions {
+    parentPath?: string;
+}
+
+export interface RegisterNavigationItemsOptions {
+    menuId?: string;
+}
+
+export const RootMenuId = "root";
+
 export abstract class AbstractRuntime<TRoute = unknown, TNavigationItem = unknown> {
     protected readonly _logger: RuntimeLogger;
     protected readonly _eventBus: EventBus;
@@ -23,13 +33,13 @@ export abstract class AbstractRuntime<TRoute = unknown, TNavigationItem = unknow
         this._sessionAccessor = sessionAccessor;
     }
 
-    abstract registerRoutes(routes: TRoute[]): void;
+    abstract registerRoutes(routes: TRoute[], options?: RegisterRoutesOptions): void;
 
     abstract get routes(): TRoute[];
 
-    abstract registerNavigationItems(navigationItems: TNavigationItem[]): void;
+    abstract registerNavigationItems(navigationItems: TNavigationItem[], options?: RegisterNavigationItemsOptions): void;
 
-    abstract get navigationItems(): TNavigationItem[];
+    abstract getNavigationItems(menuId?: string): TNavigationItem[];
 
     get logger() {
         return this._logger;

--- a/packages/core/src/runtime/abstractRuntime.ts
+++ b/packages/core/src/runtime/abstractRuntime.ts
@@ -15,10 +15,10 @@ export interface RegisterRoutesOptions {
 }
 
 export interface RegisterNavigationItemsOptions {
-    menuId?: string;
+    menuPath?: string;
 }
 
-export const RootMenuId = "root";
+export const RootMenuPath = "/";
 
 export abstract class AbstractRuntime<TRoute = unknown, TNavigationItem = unknown> {
     protected readonly _logger: RuntimeLogger;

--- a/packages/core/src/runtime/abstractRuntime.ts
+++ b/packages/core/src/runtime/abstractRuntime.ts
@@ -11,7 +11,7 @@ export interface RuntimeOptions {
 }
 
 export interface RegisterRoutesOptions {
-    parentPath?: string;
+    layoutPath?: string;
 }
 
 export interface RegisterNavigationItemsOptions {

--- a/packages/react-router/src/navigationItemRegistry.ts
+++ b/packages/react-router/src/navigationItemRegistry.ts
@@ -28,18 +28,20 @@ export type RootNavigationItem = NavigationItem & {
 };
 
 export class NavigationItemRegistry {
-    #items: RootNavigationItem[];
+    #menus: Map<string, RootNavigationItem[]>;
 
     constructor() {
-        this.#items = [];
+        this.#menus = new Map();
     }
 
-    add(navigationItems: RootNavigationItem[]) {
+    add(menuId: string, navigationItems: RootNavigationItem[]) {
         // Create a new array so the navigation items array is immutable.
-        this.#items = [...this.#items, ...navigationItems];
+        const items = [...(this.#menus.get(menuId) ?? []), ...navigationItems];
+
+        this.#menus.set(menuId, items);
     }
 
-    get items() {
-        return this.#items;
+    getItems(menuId: string) {
+        return this.#menus.get(menuId);
     }
 }

--- a/packages/react-router/src/navigationItemRegistry.ts
+++ b/packages/react-router/src/navigationItemRegistry.ts
@@ -28,20 +28,16 @@ export type RootNavigationItem = NavigationItem & {
 };
 
 export class NavigationItemRegistry {
-    #menus: Map<string, RootNavigationItem[]>;
+    readonly #menus: Map<string, RootNavigationItem[]> = new Map();
 
-    constructor() {
-        this.#menus = new Map();
-    }
-
-    add(menuId: string, navigationItems: RootNavigationItem[]) {
+    add(menuPath: string, navigationItems: RootNavigationItem[]) {
         // Create a new array so the navigation items array is immutable.
-        const items = [...(this.#menus.get(menuId) ?? []), ...navigationItems];
+        const items = [...(this.#menus.get(menuPath) ?? []), ...navigationItems];
 
-        this.#menus.set(menuId, items);
+        this.#menus.set(menuPath, items);
     }
 
-    getItems(menuId: string) {
-        return this.#menus.get(menuId);
+    getItems(menuPath: string) {
+        return this.#menus.get(menuPath);
     }
 }

--- a/packages/react-router/src/navigationItemRegistry.ts
+++ b/packages/react-router/src/navigationItemRegistry.ts
@@ -30,14 +30,17 @@ export type RootNavigationItem = NavigationItem & {
 export class NavigationItemRegistry {
     readonly #menus: Map<string, RootNavigationItem[]> = new Map();
 
-    add(menuPath: string, navigationItems: RootNavigationItem[]) {
+    add(menuId: string, navigationItems: RootNavigationItem[]) {
         // Create a new array so the navigation items array is immutable.
-        const items = [...(this.#menus.get(menuPath) ?? []), ...navigationItems];
+        const items = [
+            ...(this.#menus.get(menuId) ?? []),
+            ...navigationItems
+        ];
 
-        this.#menus.set(menuPath, items);
+        this.#menus.set(menuId, items);
     }
 
-    getItems(menuPath: string) {
-        return this.#menus.get(menuPath);
+    getItems(menuId: string) {
+        return this.#menus.get(menuId);
     }
 }

--- a/packages/react-router/src/routeRegistry.ts
+++ b/packages/react-router/src/routeRegistry.ts
@@ -1,3 +1,4 @@
+import type { RegisterRoutesOptions } from "@squide/core";
 import type { RouteObject } from "react-router-dom";
 
 export type Route = RouteObject;
@@ -9,13 +10,59 @@ export type RootRoute = Route & {
 export class RouteRegistry {
     #routes: RootRoute[];
 
+    // Using a denormalized routes structure to speed up the look up for parent routes
+    // as we expect that 99% of the time, the parent will be a root route.
+    #denormalizedRoutes: Map<string, RootRoute | Route>;
+
     constructor() {
         this.#routes = [];
+        this.#denormalizedRoutes = new Map();
     }
 
-    add(routes: RootRoute[]) {
+    add(routes: RootRoute[] | Route[], { parentPath }: RegisterRoutesOptions = {}) {
+        if (parentPath) {
+            this.#addNestedRoutes(routes, parentPath);
+        } else {
+            this.#addRootRoutes(routes);
+        }
+    }
+
+    #addRootRoutes(routes: RootRoute[]) {
+        // Save denormalized entries to speed up the registration future of nested routes.
+        routes.forEach(x => {
+            const key = x.index ? "/index" : x.path!;
+
+            this.#denormalizedRoutes.set(key, x);
+        });
+
         // Create a new array so the routes array is immutable.
         this.#routes = [...this.#routes, ...routes];
+    }
+
+    // TODO: in docs if looking to append to an index route, add "/index" at the end.
+    #addNestedRoutes(routes: Route[], parentPath: string) {
+        const parentRoute = this.#denormalizedRoutes.get(parentPath);
+
+        if (!parentRoute) {
+            throw new Error(`[squide] No route has been registered for the parentPath: ${parentPath}. Make sure to register the module including the parent route before registring a nested route for that route.`);
+        }
+
+        // Register new nested routes as children of their parent route.
+        parentRoute.children = [
+            ...(parentRoute.children ?? []),
+            ...routes
+        ];
+
+        // Save denormalized entries for future usage.
+        routes.forEach(x => {
+            const key = `${parentPath}${parentPath.endsWith("/") ? "" : "/"}${x.index ? "index" : x.path}`;
+
+            this.#denormalizedRoutes.set(key, x);
+        });
+
+        // Create a new array since the routes array is immutable and a nested
+        // object has been updated.
+        this.#routes = [...this.#routes];
     }
 
     get routes() {

--- a/packages/react-router/src/runtime.ts
+++ b/packages/react-router/src/runtime.ts
@@ -1,4 +1,4 @@
-import { AbstractRuntime, RootMenuId, type RegisterNavigationItemsOptions, type RegisterRoutesOptions } from "@squide/core";
+import { AbstractRuntime, RootMenuPath, type RegisterNavigationItemsOptions, type RegisterRoutesOptions } from "@squide/core";
 import { NavigationItemRegistry, type RootNavigationItem } from "./navigationItemRegistry.ts";
 import { RouteRegistry, type RootRoute, type Route } from "./routeRegistry.ts";
 
@@ -22,19 +22,19 @@ export class Runtime extends AbstractRuntime<RootRoute | Route, RootNavigationIt
         return this.#routeRegistry.routes;
     }
 
-    registerNavigationItems(navigationItems: RootNavigationItem[], { menuId = RootMenuId }: RegisterNavigationItemsOptions = {}) {
-        this.#navigationItemRegistry.add(menuId, navigationItems);
+    registerNavigationItems(navigationItems: RootNavigationItem[], { menuPath = RootMenuPath }: RegisterNavigationItemsOptions = {}) {
+        this.#navigationItemRegistry.add(menuPath, navigationItems);
 
-        const items = this.#navigationItemRegistry.getItems(menuId)!;
+        const items = this.#navigationItemRegistry.getItems(menuPath)!;
 
         this._logger.debug(
-            `[squide] The following navigation item${navigationItems.length !== 1 ? "s" : ""} has been registered to the "${menuId}" menu for a total of ${items.length} item${items.length !== 1 ? "s" : ""}.`,
+            `[squide] The following navigation item${navigationItems.length !== 1 ? "s" : ""} has been registered to the "${menuPath}" menu for a total of ${items.length} item${items.length !== 1 ? "s" : ""}.`,
             navigationItems,
             items
         );
     }
 
-    getNavigationItems(menuId: string = RootMenuId) {
-        return this.#navigationItemRegistry.getItems(menuId) ?? [];
+    getNavigationItems(menuPath: string = RootMenuPath) {
+        return this.#navigationItemRegistry.getItems(menuPath) ?? [];
     }
 }

--- a/packages/react-router/src/runtime.ts
+++ b/packages/react-router/src/runtime.ts
@@ -9,7 +9,7 @@ export class Runtime extends AbstractRuntime<RootRoute | Route, RootNavigationIt
     registerRoutes(routes: RootRoute[] | Route[], options: RegisterRoutesOptions = {}) {
         this.#routeRegistry.add(routes, options);
 
-        const parentLog = options.parentPath ? `as children of the "${options.parentPath}" route` : "";
+        const parentLog = options.layoutPath ? `as children of the "${options.layoutPath}" route` : "";
 
         this._logger.debug(
             `[squide] The following route${routes.length !== 1 ? "s" : ""} has been registered${parentLog} for a total of ${this.#routeRegistry.routes.length} route${this.#routeRegistry.routes.length !== 1 ? "s" : ""}.`,

--- a/packages/react-router/src/runtime.ts
+++ b/packages/react-router/src/runtime.ts
@@ -1,4 +1,4 @@
-import { AbstractRuntime, RootMenuPath, type RegisterNavigationItemsOptions, type RegisterRoutesOptions } from "@squide/core";
+import { AbstractRuntime, RootMenuId, type RegisterNavigationItemsOptions, type RegisterRoutesOptions } from "@squide/core";
 import { NavigationItemRegistry, type RootNavigationItem } from "./navigationItemRegistry.ts";
 import { RouteRegistry, type RootRoute, type Route } from "./routeRegistry.ts";
 
@@ -22,19 +22,19 @@ export class Runtime extends AbstractRuntime<RootRoute | Route, RootNavigationIt
         return this.#routeRegistry.routes;
     }
 
-    registerNavigationItems(navigationItems: RootNavigationItem[], { menuPath = RootMenuPath }: RegisterNavigationItemsOptions = {}) {
-        this.#navigationItemRegistry.add(menuPath, navigationItems);
+    registerNavigationItems(navigationItems: RootNavigationItem[], { menuId = RootMenuId }: RegisterNavigationItemsOptions = {}) {
+        this.#navigationItemRegistry.add(menuId, navigationItems);
 
-        const items = this.#navigationItemRegistry.getItems(menuPath)!;
+        const items = this.#navigationItemRegistry.getItems(menuId)!;
 
         this._logger.debug(
-            `[squide] The following navigation item${navigationItems.length !== 1 ? "s" : ""} has been registered to the "${menuPath}" menu for a total of ${items.length} item${items.length !== 1 ? "s" : ""}.`,
+            `[squide] The following navigation item${navigationItems.length !== 1 ? "s" : ""} has been registered to the "${menuId}" menu for a total of ${items.length} item${items.length !== 1 ? "s" : ""}.`,
             navigationItems,
             items
         );
     }
 
-    getNavigationItems(menuPath: string = RootMenuPath) {
-        return this.#navigationItemRegistry.getItems(menuPath) ?? [];
+    getNavigationItems(menuId: string = RootMenuId) {
+        return this.#navigationItemRegistry.getItems(menuId) ?? [];
     }
 }

--- a/packages/react-router/src/runtime.ts
+++ b/packages/react-router/src/runtime.ts
@@ -1,16 +1,18 @@
-import { AbstractRuntime } from "@squide/core";
+import { AbstractRuntime, RootMenuId, type RegisterNavigationItemsOptions, type RegisterRoutesOptions } from "@squide/core";
 import { NavigationItemRegistry, type RootNavigationItem } from "./navigationItemRegistry.ts";
-import { RouteRegistry, type RootRoute } from "./routeRegistry.ts";
+import { RouteRegistry, type RootRoute, type Route } from "./routeRegistry.ts";
 
-export class Runtime extends AbstractRuntime<RootRoute, RootNavigationItem> {
+export class Runtime extends AbstractRuntime<RootRoute | Route, RootNavigationItem> {
     readonly #routeRegistry = new RouteRegistry();
     readonly #navigationItemRegistry = new NavigationItemRegistry();
 
-    registerRoutes(routes: RootRoute[]) {
-        this.#routeRegistry.add(routes);
+    registerRoutes(routes: RootRoute[] | Route[], options: RegisterRoutesOptions = {}) {
+        this.#routeRegistry.add(routes, options);
+
+        const parentLog = options.parentPath ? `as children of the "${options.parentPath}" route` : "";
 
         this._logger.debug(
-            `[squide] The following route${routes.length !== 1 ? "s" : ""} has been registered for a total of ${this.#routeRegistry.routes.length} route${this.#routeRegistry.routes.length !== 1 ? "s" : ""}.`,
+            `[squide] The following route${routes.length !== 1 ? "s" : ""} has been registered${parentLog} for a total of ${this.#routeRegistry.routes.length} route${this.#routeRegistry.routes.length !== 1 ? "s" : ""}.`,
             routes,
             this.#routeRegistry.routes
         );
@@ -20,17 +22,19 @@ export class Runtime extends AbstractRuntime<RootRoute, RootNavigationItem> {
         return this.#routeRegistry.routes;
     }
 
-    registerNavigationItems(navigationItems: RootNavigationItem[]) {
-        this.#navigationItemRegistry.add(navigationItems);
+    registerNavigationItems(navigationItems: RootNavigationItem[], { menuId = RootMenuId }: RegisterNavigationItemsOptions = {}) {
+        this.#navigationItemRegistry.add(menuId, navigationItems);
+
+        const items = this.#navigationItemRegistry.getItems(menuId)!;
 
         this._logger.debug(
-            `[squide] The following navigation item${navigationItems.length !== 1 ? "s" : ""} has been registered for a total of ${this.#navigationItemRegistry.items.length} item${this.#navigationItemRegistry.items.length !== 1 ? "s" : ""}.`,
+            `[squide] The following navigation item${navigationItems.length !== 1 ? "s" : ""} has been registered to the "${menuId}" menu for a total of ${items.length} item${items.length !== 1 ? "s" : ""}.`,
             navigationItems,
-            this.#navigationItemRegistry.items
+            items
         );
     }
 
-    get navigationItems() {
-        return this.#navigationItemRegistry.items;
+    getNavigationItems(menuId: string = RootMenuId) {
+        return this.#navigationItemRegistry.getItems(menuId) ?? [];
     }
 }

--- a/packages/react-router/src/useNavigationItems.ts
+++ b/packages/react-router/src/useNavigationItems.ts
@@ -1,8 +1,8 @@
 import { useRuntime } from "@squide/core";
 import type { Runtime } from "./runtime.ts";
 
-export function useNavigationItems(menuPath?: string) {
+export function useNavigationItems(menuId?: string) {
     const runtime = useRuntime() as Runtime;
 
-    return runtime.getNavigationItems(menuPath);
+    return runtime.getNavigationItems(menuId);
 }

--- a/packages/react-router/src/useNavigationItems.ts
+++ b/packages/react-router/src/useNavigationItems.ts
@@ -1,8 +1,8 @@
 import { useRuntime } from "@squide/core";
 import type { Runtime } from "./runtime.ts";
 
-export function useNavigationItems() {
+export function useNavigationItems(menuId?: string) {
     const runtime = useRuntime() as Runtime;
 
-    return runtime.navigationItems;
+    return runtime.getNavigationItems(menuId);
 }

--- a/packages/react-router/src/useNavigationItems.ts
+++ b/packages/react-router/src/useNavigationItems.ts
@@ -1,8 +1,8 @@
 import { useRuntime } from "@squide/core";
 import type { Runtime } from "./runtime.ts";
 
-export function useNavigationItems(menuId?: string) {
+export function useNavigationItems(menuPath?: string) {
     const runtime = useRuntime() as Runtime;
 
-    return runtime.getNavigationItems(menuId);
+    return runtime.getNavigationItems(menuPath);
 }

--- a/packages/react-router/tests/runtime.test.tsx
+++ b/packages/react-router/tests/runtime.test.tsx
@@ -227,11 +227,6 @@ describe("registerRoutes", () => {
     });
 });
 
-/*
-- can register a root navigation item
-- can register a navigation item for a specific menu id
-*/
-
 describe("registerNavigationItems", () => {
     test("can register a root navigation link", () => {
         const runtime = new Runtime();
@@ -280,7 +275,7 @@ describe("registerNavigationItems", () => {
         expect(runtime.getNavigationItems("link-menu")[0].to).toBe("/link");
     });
 
-    test("ca register a navigation section for a specific menu id", () => {
+    test("can register a navigation section for a specific menu id", () => {
         const runtime = new Runtime();
 
         runtime.registerNavigationItems([
@@ -297,5 +292,87 @@ describe("registerNavigationItems", () => {
 
         expect(runtime.getNavigationItems("section-menu").length).toBe(1);
         expect(runtime.getNavigationItems("section-menu")[0].label).toBe("Section");
+    });
+});
+
+describe("getNavigationItems", () => {
+    test("when no menu id is specified, returns all the registered navigation items for the root menu", () => {
+        const runtime = new Runtime();
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-1",
+                label: "Item 1"
+            },
+            {
+                to: "/item-2",
+                label: "Item 2"
+            }
+        ]);
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-3",
+                label: "Item 3"
+            }
+        ]);
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-4",
+                label: "Item 4"
+            }
+        ], { menuId: "menu-1" });
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-5",
+                label: "Item 5"
+            }
+        ], { menuId: "menu-2" });
+
+        expect(runtime.getNavigationItems().length).toBe(3);
+        expect(runtime.getNavigationItems()[0].to).toBe("/item-1");
+        expect(runtime.getNavigationItems()[1].to).toBe("/item-2");
+        expect(runtime.getNavigationItems()[2].to).toBe("/item-3");
+    });
+
+    test("when no menu id is specified, returns all the registered navigation items for that specific menu", () => {
+        const runtime = new Runtime();
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-1",
+                label: "Item 1"
+            },
+            {
+                to: "/item-2",
+                label: "Item 2"
+            }
+        ]);
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-3",
+                label: "Item 3"
+            }
+        ]);
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-4",
+                label: "Item 4"
+            }
+        ], { menuId: "menu-1" });
+
+        runtime.registerNavigationItems([
+            {
+                to: "/item-5",
+                label: "Item 5"
+            }
+        ], { menuId: "menu-2" });
+
+        expect(runtime.getNavigationItems("menu-1").length).toBe(1);
+        expect(runtime.getNavigationItems("menu-1")[0].to).toBe("/item-4");
     });
 });

--- a/packages/react-router/tests/runtime.test.tsx
+++ b/packages/react-router/tests/runtime.test.tsx
@@ -48,11 +48,6 @@ describe("createIndexKey", () => {
     });
 });
 
-/*
-- "can register a nested route for an index route"
-- "can register a nested route for the root index route"
-*/
-
 describe("registerRoutes", () => {
     test("can register a root route", () => {
         const runtime = new Runtime();
@@ -69,12 +64,12 @@ describe("registerRoutes", () => {
         expect(runtime.routes[0].path).toBe("/root");
     });
 
-    test("when the parent route has already been registered, register the nested route", () => {
+    test("when the layout route has already been registered, register the nested route", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
-                path: "/parent",
+                path: "/layout",
                 element: <div>Hello!</div>
             }
         ]);
@@ -83,25 +78,25 @@ describe("registerRoutes", () => {
 
         runtime.registerRoutes([
             {
-                path: "/parent/nested",
+                path: "/layout/nested",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent" });
+        ], { layoutPath: "/layout" });
 
         expect(runtime.routes.length).toBe(1);
         expect(runtime.routes[0].children).toBeDefined();
         expect(runtime.routes[0].children?.length).toBe(1);
     });
 
-    test("when the parent route has not already been registered, do not register the nested route", () => {
+    test("when the layout route has not already been registered, do not register the nested route", () => {
         const runtime = new Runtime();
 
         expect(() => runtime.registerRoutes([
             {
-                path: "/parent/nested",
+                path: "/layout/nested",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent" })).toThrow();
+        ], { layoutPath: "/layout" })).toThrow();
     });
 
     test("can register a deeply nested route", () => {
@@ -109,78 +104,78 @@ describe("registerRoutes", () => {
 
         runtime.registerRoutes([
             {
-                path: "/parent",
+                path: "/layout",
                 element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
-                path: "/parent/nested",
+                path: "/layout/nested",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent" });
+        ], { layoutPath: "/layout" });
 
         runtime.registerRoutes([
             {
-                path: "/parent/nested/another-level",
+                path: "/layout/nested/another-level",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent/nested" });
+        ], { layoutPath: "/layout/nested" });
 
         expect(runtime.routes.length).toBe(1);
         expect(runtime.routes[0].children![0].children).toBeDefined();
         expect(runtime.routes[0].children![0].children?.length).toBe(1);
     });
 
-    test("when the parent path has a trailing separator but the parent route path doesn't have a trailing separator, the nested route is registered", () => {
+    test("when the layout path has a trailing separator but the layout route path doesn't have a trailing separator, the nested route is registered", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
-                path: "/parent",
+                path: "/layout",
                 element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
-                path: "/parent/nested",
+                path: "/layout/nested",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent/" });
+        ], { layoutPath: "/layout/" });
 
         expect(runtime.routes[0].children).toBeDefined();
         expect(runtime.routes[0].children!.length).toBe(1);
     });
 
-    test("when the parent path doesn't have a trailing separator but the parent route path have a trailing separator, the nested route is registered", () => {
+    test("when the layout path doesn't have a trailing separator but the layout route path have a trailing separator, the nested route is registered", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
-                path: "/parent/",
+                path: "/layout/",
                 element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
-                path: "/parent/nested",
+                path: "/layout/nested",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent" });
+        ], { layoutPath: "/layout" });
 
         expect(runtime.routes[0].children).toBeDefined();
         expect(runtime.routes[0].children!.length).toBe(1);
     });
 
-    test("can register a nested route for an index parent route", () => {
+    test("can register a nested route for an index layout route", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
-                path: "/parent",
+                path: "/layout",
                 element: <div>Hello!</div>
             }
         ]);
@@ -190,18 +185,18 @@ describe("registerRoutes", () => {
                 index: true,
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent" });
+        ], { layoutPath: "/layout" });
 
         runtime.registerRoutes([
             {
-                path: "/parent/another-level",
+                path: "/layout/another-level",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/parent/$index$" });
+        ], { layoutPath: "/layout/$index$" });
 
         expect(runtime.routes[0].children![0].children).toBeDefined();
         expect(runtime.routes[0].children![0].children?.length).toBe(1);
-        expect(runtime.routes[0].children![0].children![0].path).toBe("/parent/another-level");
+        expect(runtime.routes[0].children![0].children![0].path).toBe("/layout/another-level");
     });
 
     test("can register a nested route for the root index route", () => {
@@ -219,7 +214,7 @@ describe("registerRoutes", () => {
                 path: "/nested",
                 element: <div>Hello!</div>
             }
-        ], { parentPath: "/$index$" });
+        ], { layoutPath: "/$index$" });
 
         expect(runtime.routes[0].children).toBeDefined();
         expect(runtime.routes[0].children?.length).toBe(1);

--- a/packages/react-router/tests/runtime.test.tsx
+++ b/packages/react-router/tests/runtime.test.tsx
@@ -1,0 +1,523 @@
+import { createIndexKey, type Route } from "../src/routeRegistry.ts";
+import { Runtime } from "../src/runtime.ts";
+
+function DummyComponent() {
+    return (
+        <div>I am a dummy component!</div>
+    );
+}
+
+describe("createIndexKey", () => {
+    /*
+    TODO: same segment twice?!?! (not sure if this is an actual valid case)
+    */
+
+    test("when the route is an index route, append \"index\" to the parent path", () => {
+        const result1 = createIndexKey({
+            index: true,
+            element: <DummyComponent />
+        }, "/");
+
+        expect(result1).toBe("/$index$");
+
+        const result2 = createIndexKey({
+            index: true,
+            element: <DummyComponent />
+        }, "/parent");
+
+        expect(result2).toBe("/parent/$index$");
+    });
+
+    test("when the route is not an index route, append the route path to the parent path", () => {
+        const result1 = createIndexKey({
+            path: "/nested",
+            element: <DummyComponent />
+        }, "/");
+
+        expect(result1).toBe("/nested");
+
+        const result2 = createIndexKey({
+            path: "/nested",
+            element: <DummyComponent />
+        }, "/parent");
+
+        expect(result2).toBe("/parent/nested");
+    });
+
+    test("add a separator between both paths", () => {
+        const result1 = createIndexKey({
+            path: "nested",
+            element: <DummyComponent />
+        }, "/");
+
+        expect(result1).toBe("/nested");
+
+        const result2 = createIndexKey({
+            path: "nested",
+            element: <DummyComponent />
+        }, "/parent");
+
+        expect(result2).toBe("/parent/nested");
+    });
+
+    test("when the parent path ends with a \"/\", do not add an additional separator between both paths", () => {
+        const result1 = createIndexKey({
+            path: "nested",
+            element: <DummyComponent />
+        }, "/");
+
+        expect(result1).toBe("/nested");
+
+        const result2 = createIndexKey({
+            path: "nested",
+            element: <DummyComponent />
+        }, "/parent/");
+
+        expect(result2).toBe("/parent/nested");
+    });
+
+    test("when the nested route path starts with a \"/\", do not add an additional separator between both paths", () => {
+        const result = createIndexKey({
+            path: "/nested",
+            element: <DummyComponent />
+        }, "/parent");
+
+        expect(result).toBe("/parent/nested");
+    });
+
+    test("when the parent path ends with a separator and the route path starts with a separator, remove the route path separator", () => {
+        const result1 = createIndexKey({
+            path: "/nested",
+            element: <DummyComponent />
+        }, "/");
+
+        expect(result1).toBe("/nested");
+
+        const result2 = createIndexKey({
+            path: "/nested",
+            element: <DummyComponent />
+        }, "/parent/");
+
+        expect(result2).toBe("/parent/nested");
+    });
+
+    test("when the route path already includes the parent path, do not concatenate the paths", () => {
+        const result = createIndexKey({
+            path: "/parent/nested",
+            element: <DummyComponent />
+        }, "/parent");
+
+        expect(result).toBe("/parent/nested");
+    });
+
+    test("when the route path ends with a separator, strip the separator", () => {
+        const result1 = createIndexKey({
+            path: "/nested/",
+            element: <DummyComponent />
+        }, "/");
+
+        expect(result1).toBe("/nested");
+
+        const result2 = createIndexKey({
+            path: "/nested/",
+            element: <DummyComponent />
+        }, "/parent");
+
+        expect(result2).toBe("/parent/nested");
+    });
+});
+
+describe("registerRoutes", () => {
+    test("can register a root route", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/root",
+                element: <DummyComponent />,
+                hoist: true
+            }
+        ]);
+
+        expect(runtime.routes.length).toBe(1);
+        expect(runtime.routes[0].path).toBe("/root");
+    });
+
+    test("when the parent route has already been registered, do not register the nested route", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        expect(runtime.routes.length).toBe(1);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes.length).toBe(1);
+        expect(runtime.routes[0].children).toBeDefined();
+        expect(runtime.routes[0].children?.length).toBe(1);
+    });
+
+    test("when the parent route has not already been registered, do not register the nested route", () => {
+        const runtime = new Runtime();
+
+        expect(() => runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" })).toThrow();
+    });
+
+    test("can register a deeply nested route", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        runtime.registerRoutes([
+            {
+                path: "/another-level",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent/nested" });
+
+        expect(runtime.routes.length).toBe(1);
+        expect(runtime.routes[0].children![0].children).toBeDefined();
+        expect(runtime.routes[0].children![0].children?.length).toBe(1);
+    });
+
+    test("when the nested route path do not includes the parent path, concatenate the paths", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
+
+        runtime.registerRoutes([
+            {
+                path: "/another-level",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent/nested" });
+
+        expect(runtime.routes[0].children![0].children![0].path).toBe("/parent/nested/another-level");
+
+        runtime.registerRoutes([
+            {
+                path: "/",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/" });
+
+        expect(runtime.routes[1].children![0].path).toBe("/nested");
+    });
+
+    test("when the nested route path already includes the parent path, do not concatenate the paths", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/parent/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
+
+        runtime.registerRoutes([
+            {
+                path: "/parent/nested/another-level",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent/nested" });
+
+        expect(runtime.routes[0].children![0].children![0].path).toBe("/parent/nested/another-level");
+
+        runtime.registerRoutes([
+            {
+                path: "/",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/" });
+
+        expect(runtime.routes[1].children![0].path).toBe("/nested");
+    });
+
+    test("when the nested route is an index route, do not set a path", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                index: true,
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes[0].children![0].path).toBeUndefined();
+        expect(runtime.routes[0].children![0].index).toBeTruthy();
+    });
+
+    test("add a separator between both paths", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
+
+        runtime.registerRoutes([
+            {
+                path: "/",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/" });
+
+        expect(runtime.routes[1].children![0].path).toBe("/nested");
+    });
+
+    test("when the parent path ends with a \"/\", do not add an additional separator between both paths", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent/" });
+
+        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
+
+        runtime.registerRoutes([
+            {
+                path: "/",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/" });
+
+        expect(runtime.routes[1].children![0].path).toBe("/nested");
+    });
+
+    test("when the nested route path starts with a \"/\", do not add an additional separator between both paths", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
+    });
+
+
+    test("when the parent path ends with a separator and the route path starts with a separator, remove the route path separator", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent/",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
+
+        runtime.registerRoutes([
+            {
+                path: "/",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/" });
+
+        expect(runtime.routes[1].children![0].path).toBe("/nested");
+    });
+
+    test("when the nested route path ends with a separator, strip the separator", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "/nested/",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
+    });
+
+    test("can register a nested route for an index route", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                path: "/parent",
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                index: true,
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent" });
+
+        runtime.registerRoutes([
+            {
+                path: "another-level",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/parent/$index$" });
+
+        expect(runtime.routes[0].children![0].children).toBeDefined();
+        expect(runtime.routes[0].children![0].children?.length).toBe(1);
+        expect(runtime.routes[0].children![0].children![0].path).toBe("/parent/another-level");
+    });
+
+    test("can register a nested route for the root index route", () => {
+        const runtime = new Runtime();
+
+        runtime.registerRoutes([
+            {
+                index: true,
+                element: <DummyComponent />
+            }
+        ]);
+
+        runtime.registerRoutes([
+            {
+                path: "nested",
+                element: <DummyComponent />
+            }
+        ], { parentPath: "/$index$" });
+
+        expect(runtime.routes[0].children).toBeDefined();
+        expect(runtime.routes[0].children?.length).toBe(1);
+        expect(runtime.routes[0].children![0].path).toBe("/nested");
+    });
+});
+
+// describe("registerNavigationItems", () => {
+// });

--- a/packages/react-router/tests/runtime.test.tsx
+++ b/packages/react-router/tests/runtime.test.tsx
@@ -1,131 +1,57 @@
-import { createIndexKey, type Route } from "../src/routeRegistry.ts";
+import { createIndexKey } from "../src/routeRegistry.ts";
 import { Runtime } from "../src/runtime.ts";
 
-function DummyComponent() {
-    return (
-        <div>I am a dummy component!</div>
-    );
-}
+/*
+- "when the route is not an index route and the path ends with a separator, strip the separator"
+*/
 
 describe("createIndexKey", () => {
-    /*
-    TODO: same segment twice?!?! (not sure if this is an actual valid case)
-    */
-
     test("when the route is an index route, append \"index\" to the parent path", () => {
         const result1 = createIndexKey({
             index: true,
-            element: <DummyComponent />
+            element: <div>Hello!</div>
         }, "/");
 
         expect(result1).toBe("/$index$");
 
         const result2 = createIndexKey({
             index: true,
-            element: <DummyComponent />
+            element: <div>Hello!</div>
         }, "/parent");
 
         expect(result2).toBe("/parent/$index$");
     });
 
-    test("when the route is not an index route, append the route path to the parent path", () => {
+    test("when the route is not an index route, return the route path", () => {
         const result1 = createIndexKey({
             path: "/nested",
-            element: <DummyComponent />
+            element: <div>Hello!</div>
         }, "/");
 
         expect(result1).toBe("/nested");
 
         const result2 = createIndexKey({
-            path: "/nested",
-            element: <DummyComponent />
-        }, "/parent");
-
-        expect(result2).toBe("/parent/nested");
-    });
-
-    test("add a separator between both paths", () => {
-        const result1 = createIndexKey({
-            path: "nested",
-            element: <DummyComponent />
-        }, "/");
-
-        expect(result1).toBe("/nested");
-
-        const result2 = createIndexKey({
-            path: "nested",
-            element: <DummyComponent />
-        }, "/parent");
-
-        expect(result2).toBe("/parent/nested");
-    });
-
-    test("when the parent path ends with a \"/\", do not add an additional separator between both paths", () => {
-        const result1 = createIndexKey({
-            path: "nested",
-            element: <DummyComponent />
-        }, "/");
-
-        expect(result1).toBe("/nested");
-
-        const result2 = createIndexKey({
-            path: "nested",
-            element: <DummyComponent />
-        }, "/parent/");
-
-        expect(result2).toBe("/parent/nested");
-    });
-
-    test("when the nested route path starts with a \"/\", do not add an additional separator between both paths", () => {
-        const result = createIndexKey({
-            path: "/nested",
-            element: <DummyComponent />
-        }, "/parent");
-
-        expect(result).toBe("/parent/nested");
-    });
-
-    test("when the parent path ends with a separator and the route path starts with a separator, remove the route path separator", () => {
-        const result1 = createIndexKey({
-            path: "/nested",
-            element: <DummyComponent />
-        }, "/");
-
-        expect(result1).toBe("/nested");
-
-        const result2 = createIndexKey({
-            path: "/nested",
-            element: <DummyComponent />
-        }, "/parent/");
-
-        expect(result2).toBe("/parent/nested");
-    });
-
-    test("when the route path already includes the parent path, do not concatenate the paths", () => {
-        const result = createIndexKey({
             path: "/parent/nested",
-            element: <DummyComponent />
-        }, "/parent");
-
-        expect(result).toBe("/parent/nested");
-    });
-
-    test("when the route path ends with a separator, strip the separator", () => {
-        const result1 = createIndexKey({
-            path: "/nested/",
-            element: <DummyComponent />
-        }, "/");
-
-        expect(result1).toBe("/nested");
-
-        const result2 = createIndexKey({
-            path: "/nested/",
-            element: <DummyComponent />
+            element: <div>Hello!</div>
         }, "/parent");
 
         expect(result2).toBe("/parent/nested");
+    });
+
+    test("when the route is not an index route and the path ends with a separator, strip the separator", () => {
+        const result = createIndexKey({
+            path: "/parent/nested/",
+            element: <div>Hello!</div>
+        }, "/parent");
+
+        expect(result).toBe("/parent/nested");
     });
 });
+
+/*
+- "can register a nested route for an index route"
+- "can register a nested route for the root index route"
+*/
 
 describe("registerRoutes", () => {
     test("can register a root route", () => {
@@ -134,7 +60,7 @@ describe("registerRoutes", () => {
         runtime.registerRoutes([
             {
                 path: "/root",
-                element: <DummyComponent />,
+                element: <div>Hello!</div>,
                 hoist: true
             }
         ]);
@@ -143,13 +69,13 @@ describe("registerRoutes", () => {
         expect(runtime.routes[0].path).toBe("/root");
     });
 
-    test("when the parent route has already been registered, do not register the nested route", () => {
+    test("when the parent route has already been registered, register the nested route", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
                 path: "/parent",
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ]);
 
@@ -157,8 +83,8 @@ describe("registerRoutes", () => {
 
         runtime.registerRoutes([
             {
-                path: "/nested",
-                element: <DummyComponent />
+                path: "/parent/nested",
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent" });
 
@@ -172,8 +98,8 @@ describe("registerRoutes", () => {
 
         expect(() => runtime.registerRoutes([
             {
-                path: "/nested",
-                element: <DummyComponent />
+                path: "/parent/nested",
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent" })).toThrow();
     });
@@ -184,21 +110,21 @@ describe("registerRoutes", () => {
         runtime.registerRoutes([
             {
                 path: "/parent",
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
-                path: "/nested",
-                element: <DummyComponent />
+                path: "/parent/nested",
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent" });
 
         runtime.registerRoutes([
             {
-                path: "/another-level",
-                element: <DummyComponent />
+                path: "/parent/nested/another-level",
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent/nested" });
 
@@ -207,287 +133,69 @@ describe("registerRoutes", () => {
         expect(runtime.routes[0].children![0].children?.length).toBe(1);
     });
 
-    test("when the nested route path do not includes the parent path, concatenate the paths", () => {
+    test("when the parent path has a trailing separator but the parent route path doesn't have a trailing separator, the nested route is registered", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
                 path: "/parent",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "/nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent" });
-
-        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
-
-        runtime.registerRoutes([
-            {
-                path: "/another-level",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent/nested" });
-
-        expect(runtime.routes[0].children![0].children![0].path).toBe("/parent/nested/another-level");
-
-        runtime.registerRoutes([
-            {
-                path: "/",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/" });
-
-        expect(runtime.routes[1].children![0].path).toBe("/nested");
-    });
-
-    test("when the nested route path already includes the parent path, do not concatenate the paths", () => {
-        const runtime = new Runtime();
-
-        runtime.registerRoutes([
-            {
-                path: "/parent",
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
                 path: "/parent/nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent" });
-
-        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
-
-        runtime.registerRoutes([
-            {
-                path: "/parent/nested/another-level",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent/nested" });
-
-        expect(runtime.routes[0].children![0].children![0].path).toBe("/parent/nested/another-level");
-
-        runtime.registerRoutes([
-            {
-                path: "/",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "/nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/" });
-
-        expect(runtime.routes[1].children![0].path).toBe("/nested");
-    });
-
-    test("when the nested route is an index route, do not set a path", () => {
-        const runtime = new Runtime();
-
-        runtime.registerRoutes([
-            {
-                path: "/parent",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                index: true,
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent" });
-
-        expect(runtime.routes[0].children![0].path).toBeUndefined();
-        expect(runtime.routes[0].children![0].index).toBeTruthy();
-    });
-
-    test("add a separator between both paths", () => {
-        const runtime = new Runtime();
-
-        runtime.registerRoutes([
-            {
-                path: "/parent",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "/nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent" });
-
-        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
-
-        runtime.registerRoutes([
-            {
-                path: "/",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "/nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/" });
-
-        expect(runtime.routes[1].children![0].path).toBe("/nested");
-    });
-
-    test("when the parent path ends with a \"/\", do not add an additional separator between both paths", () => {
-        const runtime = new Runtime();
-
-        runtime.registerRoutes([
-            {
-                path: "/parent",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "nested",
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent/" });
 
-        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
-
-        runtime.registerRoutes([
-            {
-                path: "/",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/" });
-
-        expect(runtime.routes[1].children![0].path).toBe("/nested");
+        expect(runtime.routes[0].children).toBeDefined();
+        expect(runtime.routes[0].children!.length).toBe(1);
     });
 
-    test("when the nested route path starts with a \"/\", do not add an additional separator between both paths", () => {
-        const runtime = new Runtime();
-
-        runtime.registerRoutes([
-            {
-                path: "/parent",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "/nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent" });
-
-        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
-    });
-
-
-    test("when the parent path ends with a separator and the route path starts with a separator, remove the route path separator", () => {
+    test("when the parent path doesn't have a trailing separator but the parent route path have a trailing separator, the nested route is registered", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
                 path: "/parent/",
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
-                path: "/nested",
-                element: <DummyComponent />
+                path: "/parent/nested",
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent" });
 
-        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
-
-        runtime.registerRoutes([
-            {
-                path: "/",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "/nested",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/" });
-
-        expect(runtime.routes[1].children![0].path).toBe("/nested");
+        expect(runtime.routes[0].children).toBeDefined();
+        expect(runtime.routes[0].children!.length).toBe(1);
     });
 
-    test("when the nested route path ends with a separator, strip the separator", () => {
+    test("can register a nested route for an index parent route", () => {
         const runtime = new Runtime();
 
         runtime.registerRoutes([
             {
                 path: "/parent",
-                element: <DummyComponent />
-            }
-        ]);
-
-        runtime.registerRoutes([
-            {
-                path: "/nested/",
-                element: <DummyComponent />
-            }
-        ], { parentPath: "/parent" });
-
-        expect(runtime.routes[0].children![0].path).toBe("/parent/nested");
-    });
-
-    test("can register a nested route for an index route", () => {
-        const runtime = new Runtime();
-
-        runtime.registerRoutes([
-            {
-                path: "/parent",
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
                 index: true,
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent" });
 
         runtime.registerRoutes([
             {
-                path: "another-level",
-                element: <DummyComponent />
+                path: "/parent/another-level",
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/parent/$index$" });
 
@@ -502,14 +210,14 @@ describe("registerRoutes", () => {
         runtime.registerRoutes([
             {
                 index: true,
-                element: <DummyComponent />
+                element: <div>Hello!</div>
             }
         ]);
 
         runtime.registerRoutes([
             {
-                path: "nested",
-                element: <DummyComponent />
+                path: "/nested",
+                element: <div>Hello!</div>
             }
         ], { parentPath: "/$index$" });
 
@@ -519,5 +227,75 @@ describe("registerRoutes", () => {
     });
 });
 
-// describe("registerNavigationItems", () => {
-// });
+/*
+- can register a root navigation item
+- can register a navigation item for a specific menu id
+*/
+
+describe("registerNavigationItems", () => {
+    test("can register a root navigation link", () => {
+        const runtime = new Runtime();
+
+        runtime.registerNavigationItems([
+            {
+                to: "/root",
+                label: "Root"
+            }
+        ]);
+
+        expect(runtime.getNavigationItems().length).toBe(1);
+        expect(runtime.getNavigationItems()[0].to).toBe("/root");
+    });
+
+    test("can register a root navigation section", () => {
+        const runtime = new Runtime();
+
+        runtime.registerNavigationItems([
+            {
+                label: "Section",
+                children: [
+                    {
+                        to: "/child",
+                        label: "Child"
+                    }
+                ]
+            }
+        ]);
+
+        expect(runtime.getNavigationItems().length).toBe(1);
+        expect(runtime.getNavigationItems()[0].label).toBe("Section");
+    });
+
+    test("can register a navigation link for a specific menu id", () => {
+        const runtime = new Runtime();
+
+        runtime.registerNavigationItems([
+            {
+                to: "/link",
+                label: "Link"
+            }
+        ], { menuId: "link-menu" });
+
+        expect(runtime.getNavigationItems("link-menu").length).toBe(1);
+        expect(runtime.getNavigationItems("link-menu")[0].to).toBe("/link");
+    });
+
+    test("ca register a navigation section for a specific menu id", () => {
+        const runtime = new Runtime();
+
+        runtime.registerNavigationItems([
+            {
+                label: "Section",
+                children: [
+                    {
+                        to: "/child",
+                        label: "Child"
+                    }
+                ]
+            }
+        ], { menuId: "section-menu" });
+
+        expect(runtime.getNavigationItems("section-menu").length).toBe(1);
+        expect(runtime.getNavigationItems("section-menu")[0].label).toBe("Section");
+    });
+});

--- a/packages/react-router/tests/useNavigationItems.test.tsx
+++ b/packages/react-router/tests/useNavigationItems.test.tsx
@@ -1,31 +1,97 @@
 import { RuntimeContext } from "@squide/core";
-import { renderHook, type RenderHookOptions } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { Runtime } from "../src/runtime.ts";
 import { useNavigationItems } from "../src/useNavigationItems.ts";
 
-function renderWithRuntime<TProps>(runtime: Runtime, additionalProps: RenderHookOptions<TProps> = {}) {
-    return renderHook(() => useNavigationItems(), {
+function renderWithRuntime(runtime: Runtime, menuId?: string) {
+    return renderHook(() => useNavigationItems(menuId), {
         wrapper: ({ children }: { children?: ReactNode }) => (
             <RuntimeContext.Provider value={runtime}>
                 {children}
             </RuntimeContext.Provider>
-        ),
-        ...additionalProps
+        )
     });
 }
 
-test("returns all the registered routes", () => {
+test("when no menu id is specified, returns all the registered navigation items for the root menu", () => {
     const runtime = new Runtime();
 
     runtime.registerNavigationItems([
-        { to: "/foo", label: "Foo" },
-        { to: "/bar", label: "Bar" }
+        {
+            to: "/item-1",
+            label: "Item 1"
+        },
+        {
+            to: "/item-2",
+            label: "Item 2"
+        }
     ]);
+
+    runtime.registerNavigationItems([
+        {
+            to: "/item-3",
+            label: "Item 3"
+        }
+    ]);
+
+    runtime.registerNavigationItems([
+        {
+            to: "/item-4",
+            label: "Item 4"
+        }
+    ], { menuId: "menu-1" });
+
+    runtime.registerNavigationItems([
+        {
+            to: "/item-5",
+            label: "Item 5"
+        }
+    ], { menuId: "menu-2" });
 
     const { result } = renderWithRuntime(runtime);
 
-    expect(result.current.length).toBe(2);
+    expect(result.current.length).toBe(3);
+});
+
+test("when a menu id is specified, returns all the registered navigation items for that specific menu", () => {
+    const runtime = new Runtime();
+
+    runtime.registerNavigationItems([
+        {
+            to: "/item-1",
+            label: "Item 1"
+        },
+        {
+            to: "/item-2",
+            label: "Item 2"
+        }
+    ]);
+
+    runtime.registerNavigationItems([
+        {
+            to: "/item-3",
+            label: "Item 3"
+        }
+    ]);
+
+    runtime.registerNavigationItems([
+        {
+            to: "/item-4",
+            label: "Item 4"
+        }
+    ], { menuId: "menu-1" });
+
+    runtime.registerNavigationItems([
+        {
+            to: "/item-5",
+            label: "Item 5"
+        }
+    ], { menuId: "menu-2" });
+
+    const { result } = renderWithRuntime(runtime, "menu-1");
+
+    expect(result.current.length).toBe(1);
 });
 
 test("returned array is immutable", () => {

--- a/sample/host/src/bootstrap.tsx
+++ b/sample/host/src/bootstrap.tsx
@@ -1,10 +1,11 @@
-import { register } from "@sample/local-module";
+import { register as registerLocalModule } from "@sample/local-module";
 import { isNetlify, type AppContext } from "@sample/shared";
 import { ConsoleLogger, Runtime, RuntimeContext, registerLocalModules } from "@squide/react-router";
 import { registerRemoteModules, type RemoteDefinition } from "@squide/webpack-module-federation";
 import { StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.tsx";
+import { registerDistributedTabsPage } from "./distributedTabs/register.tsx";
 import { sessionAccessor } from "./session.ts";
 
 const Remotes: RemoteDefinition[] = [
@@ -23,9 +24,9 @@ const context: AppContext = {
     name: "Test app"
 };
 
-registerRemoteModules(Remotes, runtime, { context });
+registerLocalModules([registerDistributedTabsPage, registerLocalModule], runtime, { context });
 
-registerLocalModules([register], runtime, { context });
+registerRemoteModules(Remotes, runtime, { context });
 
 const root = createRoot(document.getElementById("root")!);
 

--- a/sample/host/src/distributedTabs/DistributedTabsLayout.tsx
+++ b/sample/host/src/distributedTabs/DistributedTabsLayout.tsx
@@ -1,0 +1,42 @@
+import { useNavigationItems, useRenderedNavigationItems, type NavigationLinkRenderProps, type RenderItemFunction, type RenderSectionFunction } from "@squide/react-router";
+import { Link, Outlet } from "react-router-dom";
+
+const renderItem: RenderItemFunction = (item, index, level) => {
+    const { label, linkProps } = item as NavigationLinkRenderProps;
+
+    return (
+        <li key={`${level}-${index}`}>
+            <Link {...linkProps}>
+                {label}
+            </Link>
+        </li>
+    );
+};
+
+const renderSection: RenderSectionFunction = elements => {
+    return (
+        <ul style={{ listStyleType: "none", margin: 0, padding: 0, display: "flex", gap: "20px" }}>
+            {elements}
+        </ul>
+    );
+};
+
+export default function DistributedTabsLayout() {
+    const navigationItems = useNavigationItems("/distributed-tabs");
+
+    const renderedTabs = useRenderedNavigationItems(navigationItems, renderItem, renderSection);
+
+    return (
+        <div>
+            <div>
+                <p>Navigate between the tabs below :)</p>
+                {renderedTabs}
+                <div style={{ padding: "20px" }}>
+                    <Outlet />
+                </div>
+            </div>
+        </div>
+    );
+}
+
+

--- a/sample/host/src/distributedTabs/DistributedTabsLayout.tsx
+++ b/sample/host/src/distributedTabs/DistributedTabsLayout.tsx
@@ -29,7 +29,7 @@ export default function DistributedTabsLayout() {
     return (
         <div>
             <div>
-                <p>Navigate between the tabs below :)</p>
+                <p>Every tab is registered by a different modules and is lazy loaded.</p>
                 {renderedTabs}
                 <div style={{ padding: "20px" }}>
                     <Outlet />

--- a/sample/host/src/distributedTabs/register.tsx
+++ b/sample/host/src/distributedTabs/register.tsx
@@ -1,0 +1,21 @@
+import type { AppContext } from "@sample/shared";
+import type { ModuleRegisterFunction, Runtime } from "@squide/react-router";
+import { lazy } from "react";
+
+const DistributedTabsLayout = lazy(() => import("./DistributedTabsLayout.tsx"));
+
+export const registerDistributedTabsPage: ModuleRegisterFunction<Runtime, AppContext> = runtime => {
+    runtime.registerRoutes([
+        {
+            path: "/distributed-tabs",
+            element: <DistributedTabsLayout />
+        }
+    ]);
+
+    runtime.registerNavigationItems([
+        {
+            to: "distributed-tabs",
+            label: "Distributed tabs"
+        }
+    ]);
+};

--- a/sample/host/src/distributedTabs/register.tsx
+++ b/sample/host/src/distributedTabs/register.tsx
@@ -15,7 +15,7 @@ export const registerDistributedTabsPage: ModuleRegisterFunction<Runtime, AppCon
     runtime.registerNavigationItems([
         {
             to: "distributed-tabs",
-            label: "Distributed tabs"
+            label: "Tabs"
         }
     ]);
 };

--- a/sample/host/src/distributedTabs/register.tsx
+++ b/sample/host/src/distributedTabs/register.tsx
@@ -14,7 +14,7 @@ export const registerDistributedTabsPage: ModuleRegisterFunction<Runtime, AppCon
 
     runtime.registerNavigationItems([
         {
-            to: "distributed-tabs",
+            to: "/distributed-tabs",
             label: "Tabs"
         }
     ]);

--- a/sample/local-module/src/WorkleapTab.tsx
+++ b/sample/local-module/src/WorkleapTab.tsx
@@ -1,0 +1,7 @@
+export default function WorkleapTab() {
+    return (
+        <div>
+            <p>This is the <span style={{ fontWeight: "bold" }}>Workleap</span> tab!</p>
+        </div>
+    );
+}

--- a/sample/local-module/src/WorkleapTab.tsx
+++ b/sample/local-module/src/WorkleapTab.tsx
@@ -1,7 +1,7 @@
 export default function WorkleapTab() {
     return (
         <div>
-            <p>This is the <span style={{ fontWeight: "bold" }}>Workleap</span> tab!</p>
+            <p>This is the <span style={{ fontWeight: "bold" }}>Workleap</span> tab from <span style={{ fontWeight: "bold" }}>@sample/local-module</span>!</p>
         </div>
     );
 }

--- a/sample/local-module/src/register.tsx
+++ b/sample/local-module/src/register.tsx
@@ -44,7 +44,7 @@ export const register: ModuleRegisterFunction<Runtime, AppContext> = (runtime, c
             index: true,
             element: <WorkleapTab />
         }
-    ], { parentPath: "/distributed-tabs" });
+    ], { layoutPath: "/distributed-tabs" });
 
     runtime.registerNavigationItems([
         {

--- a/sample/local-module/src/register.tsx
+++ b/sample/local-module/src/register.tsx
@@ -4,6 +4,7 @@ import { lazy } from "react";
 
 const About = lazy(() => import("./About.tsx"));
 const Message = lazy(() => import("./Message.tsx"));
+const WorkleapTab = lazy(() => import("./WorkleapTab.tsx"));
 
 export const register: ModuleRegisterFunction<Runtime, AppContext> = (runtime, context) => {
     console.log("Context: ", context);
@@ -35,4 +36,20 @@ export const register: ModuleRegisterFunction<Runtime, AppContext> = (runtime, c
             }
         }
     ]);
+
+    ///////
+
+    runtime.registerRoutes([
+        {
+            index: true,
+            element: <WorkleapTab />
+        }
+    ], { parentPath: "/distributed-tabs" });
+
+    runtime.registerNavigationItems([
+        {
+            to: "/distributed-tabs",
+            label: "Workleap"
+        }
+    ], { menuId: "/distributed-tabs" });
 };

--- a/sample/local-module/src/register.tsx
+++ b/sample/local-module/src/register.tsx
@@ -51,5 +51,5 @@ export const register: ModuleRegisterFunction<Runtime, AppContext> = (runtime, c
             to: "/distributed-tabs",
             label: "Workleap"
         }
-    ], { menuPath: "/distributed-tabs" });
+    ], { menuId: "/distributed-tabs" });
 };

--- a/sample/local-module/src/register.tsx
+++ b/sample/local-module/src/register.tsx
@@ -51,5 +51,5 @@ export const register: ModuleRegisterFunction<Runtime, AppContext> = (runtime, c
             to: "/distributed-tabs",
             label: "Workleap"
         }
-    ], { menuId: "/distributed-tabs" });
+    ], { menuPath: "/distributed-tabs" });
 };

--- a/sample/remote-module/src/OfficevibeTab.tsx
+++ b/sample/remote-module/src/OfficevibeTab.tsx
@@ -1,7 +1,7 @@
 export default function OfficevibeTab() {
     return (
         <div>
-            <p>This is the <span style={{ fontWeight: "bold" }}>Officevibe</span> tab!</p>
+            <p>This is the <span style={{ fontWeight: "bold" }}>Officevibe</span> tab from <span style={{ fontWeight: "bold" }}>@sample/remote-module</span>!</p>
         </div>
     );
 }

--- a/sample/remote-module/src/OfficevibeTab.tsx
+++ b/sample/remote-module/src/OfficevibeTab.tsx
@@ -1,0 +1,7 @@
+export default function OfficevibeTab() {
+    return (
+        <div>
+            <p>This is the <span style={{ fontWeight: "bold" }}>Officevibe</span> tab!</p>
+        </div>
+    );
+}

--- a/sample/remote-module/src/SkillsTab.tsx
+++ b/sample/remote-module/src/SkillsTab.tsx
@@ -1,7 +1,7 @@
 export default function SkillsTab() {
     return (
         <div>
-            <p>This is the <span style={{ fontWeight: "bold" }}>Skills</span> tab!</p>
+            <p>This is the <span style={{ fontWeight: "bold" }}>Skills</span> tab from <span style={{ fontWeight: "bold" }}>@sample/remote-module</span>!</p>
         </div>
     );
 }

--- a/sample/remote-module/src/SkillsTab.tsx
+++ b/sample/remote-module/src/SkillsTab.tsx
@@ -1,0 +1,7 @@
+export default function SkillsTab() {
+    return (
+        <div>
+            <p>This is the <span style={{ fontWeight: "bold" }}>Skills</span> tab!</p>
+        </div>
+    );
+}

--- a/sample/remote-module/src/register.tsx
+++ b/sample/remote-module/src/register.tsx
@@ -6,6 +6,8 @@ const CustomLayout = lazy(() => import("./CustomLayout.tsx"));
 const Remote = lazy(() => import("./Remote.tsx"));
 const Fetch = lazy(() => import("./Fetch.tsx"));
 const Hoisted = lazy(() => import("./Hoisted.tsx"));
+const OfficevibeTab = lazy(() => import("./OfficevibeTab.tsx"));
+const SkillsTab = lazy(() => import("./SkillsTab.tsx"));
 
 export const register: ModuleRegisterFunction<Runtime> = runtime => {
     runtime.registerRoutes([
@@ -65,4 +67,28 @@ export const register: ModuleRegisterFunction<Runtime> = runtime => {
             ]
         }
     ]);
+
+    ///////
+
+    runtime.registerRoutes([
+        {
+            path: "/distributed-tabs/officevibe",
+            element: <OfficevibeTab />
+        },
+        {
+            path: "/distributed-tabs/skills",
+            element: <SkillsTab />
+        }
+    ], { parentPath: "/distributed-tabs" });
+
+    runtime.registerNavigationItems([
+        {
+            to: "/distributed-tabs/officevibe",
+            label: "Officevibe"
+        },
+        {
+            to: "/distributed-tabs/skills",
+            label: "Skills"
+        }
+    ], { menuId: "/distributed-tabs" });
 };

--- a/sample/remote-module/src/register.tsx
+++ b/sample/remote-module/src/register.tsx
@@ -79,7 +79,7 @@ export const register: ModuleRegisterFunction<Runtime> = runtime => {
             path: "/distributed-tabs/skills",
             element: <SkillsTab />
         }
-    ], { parentPath: "/distributed-tabs" });
+    ], { layoutPath: "/distributed-tabs" });
 
     runtime.registerNavigationItems([
         {

--- a/sample/remote-module/src/register.tsx
+++ b/sample/remote-module/src/register.tsx
@@ -72,23 +72,23 @@ export const register: ModuleRegisterFunction<Runtime> = runtime => {
 
     runtime.registerRoutes([
         {
-            path: "/officevibe",
+            path: "/distributed-tabs/officevibe",
             element: <OfficevibeTab />
         },
         {
-            path: "/skills",
+            path: "/distributed-tabs/skills",
             element: <SkillsTab />
         }
     ], { parentPath: "/distributed-tabs" });
 
     runtime.registerNavigationItems([
         {
-            to: "/officevibe",
+            to: "/distributed-tabs/officevibe",
             label: "Officevibe"
         },
         {
-            to: "/skills",
+            to: "/distributed-tabs/skills",
             label: "Skills"
         }
-    ], { menuPath: "/distributed-tabs" });
+    ], { menuId: "/distributed-tabs" });
 };

--- a/sample/remote-module/src/register.tsx
+++ b/sample/remote-module/src/register.tsx
@@ -51,7 +51,7 @@ export const register: ModuleRegisterFunction<Runtime> = runtime => {
         },
         {
             to: "/hoisted",
-            label: <strong>Hoisted</strong>
+            label: <span style={{ color: "green" }}>Hoisted</span>
         },
         {
             label: "Section",
@@ -72,23 +72,23 @@ export const register: ModuleRegisterFunction<Runtime> = runtime => {
 
     runtime.registerRoutes([
         {
-            path: "/distributed-tabs/officevibe",
+            path: "/officevibe",
             element: <OfficevibeTab />
         },
         {
-            path: "/distributed-tabs/skills",
+            path: "/skills",
             element: <SkillsTab />
         }
     ], { parentPath: "/distributed-tabs" });
 
     runtime.registerNavigationItems([
         {
-            to: "/distributed-tabs/officevibe",
+            to: "/officevibe",
             label: "Officevibe"
         },
         {
-            to: "/distributed-tabs/skills",
+            to: "/skills",
             label: "Skills"
         }
-    ], { menuId: "/distributed-tabs" });
+    ], { menuPath: "/distributed-tabs" });
 };

--- a/sample/shared/src/shell/AuthenticatedLayout.tsx
+++ b/sample/shared/src/shell/AuthenticatedLayout.tsx
@@ -10,7 +10,7 @@ type RenderSectionItemFunction = (item: NavigationSectionRenderProps, index: num
 
 const renderLinkItem: RenderLinkItemFunction = ({ label, linkProps, additionalProps: { highlight, ...additionalProps } }, index, level) => {
     return (
-        <li key={`${level}-${index}`} style={{ fontWeight: highlight ? "bold" : "normal", listStyleType: "none" }}>
+        <li key={`${level}-${index}`} style={{ fontWeight: highlight ? "bold" : "normal" }}>
             <Link {...linkProps} {...additionalProps}>
                 {label}
             </Link>
@@ -20,7 +20,7 @@ const renderLinkItem: RenderLinkItemFunction = ({ label, linkProps, additionalPr
 
 const renderSectionItem: RenderSectionItemFunction = ({ label, section }, index, level) => {
     return (
-        <li key={`${level}-${index}`} style={{ listStyleType: "none", display: "flex", gap: "5px" }}>
+        <li key={`${level}-${index}`} style={{ display: "flex", gap: "5px" }}>
             {label}
             <div style={{ display: "flex", alignItems: "center", fontSize: "12px" }}>
                 ({section})
@@ -35,7 +35,7 @@ const renderItem: RenderItemFunction = (item, index, level) => {
 
 const renderSection: RenderSectionFunction = (elements, index, level) => {
     return (
-        <ul key={`${level}-${index}`} style={{ display: "flex", gap: "10px", padding: 0 }}>
+        <ul key={`${level}-${index}`} style={{ display: "flex", gap: "10px", padding: 0, listStyleType: "none" }}>
             {elements}
         </ul>
     );


### PR DESCRIPTION
Added the ability to define composable nested layouts for a federated application. A module can register a nested layout and then any modules can register routes under that specific nested layout.

This feature will allow teams to develop pages with a tabs component for which the tabs content comes from any module of the federated application.

For example, a Workleap application Settings page could include tabs for: "Officevibe", "Sharegate", "Softstart", "Didacte". The content of those tabs would not be developed directly in the Workleap application but rather in standalone repositories owned by dedicated teams from Officevibe, ShareGate, Softstart and Didacte.

NOTE:

A dedicated guide for this feature will be added in a subsequent PR.