### PR TITLE
fix: omit 'router' from routerProvidersProps

### DIFF
--- a/.changeset/neat-grapes-dress.md
+++ b/.changeset/neat-grapes-dress.md
@@ -1,0 +1,5 @@
+---
+"@squide/firefly": patch
+---
+
+Omit "router" from routerProviderProps

--- a/packages/firefly/src/AppRouter.tsx
+++ b/packages/firefly/src/AppRouter.tsx
@@ -136,7 +136,7 @@ export interface AppRouterProps {
     onLoadProtectedData?: OnLoadProtectedDataFunction;
     onCompleteRegistrations?: OnCompleteRegistrationsFunction;
     waitForMsw: boolean;
-    routerProvidersProps?: RouterProviderProps;
+    routerProvidersProps?: Omit<RouterProviderProps, "router">;
 }
 
 export function AppRouter(props: AppRouterProps) {


### PR DESCRIPTION
We should be able to use `routerProvidersProps` without having to provide a router.