### PR TITLE
refactor: Added changeset file and updated docs

### DIFF
--- a/.changeset/moody-papayas-judge.md
+++ b/.changeset/moody-papayas-judge.md
@@ -1,0 +1,8 @@
+---
+"@squide/core": patch
+"@squide/firefly": patch
+"@squide/msw": patch
+"@squide/webpack-module-federation": patch
+---
+
+Internally changed the usage of `setInterval` for `useSyncExternalStore`.

--- a/docs/reference/msw/useIsMswReady.md
+++ b/docs/reference/msw/useIsMswReady.md
@@ -9,14 +9,12 @@ If your application is using the [AppRouter](../routing/appRouter.md) component,
 ## Reference
 
 ```ts
-const isMswReady = useIsMswReady(enabled, { interval })
+const isMswReady = useIsMswReady(enabled)
 ```
 
 ### Parameters
 
 - `enabled`: Whether or not MSW is currently enabled for the application. This is especially useful to ensure the application is not waiting for MSW when in production.
-- `options`: An optional object literal of options:
-    - `interval`: The interval in milliseconds at which the hook is validating if MSW is started.
 
 ### Returns
 

--- a/docs/reference/registration/useAreModulesReady.md
+++ b/docs/reference/registration/useAreModulesReady.md
@@ -18,13 +18,8 @@ If your application supports [deferred registrations](./registerRemoteModules.md
 ## Reference
 
 ```ts
-const areModulesReady = useAreModulesReady(options?: { interval? })
+const areModulesReady = useAreModulesReady()
 ```
-
-### Parameters
-
-- `options`: An optional object literal of options:
-    - `interval`: The interval in milliseconds at which the hook is validating if the registration process is completed.
 
 ### Returns
 

--- a/docs/reference/registration/useAreModulesRegistered.md
+++ b/docs/reference/registration/useAreModulesRegistered.md
@@ -19,13 +19,8 @@ This hook should only be used by applications that support [deferred registratio
 ## Reference
 
 ```ts
-const areModulesRegistered = useAreModulesRegistered(options?: { interval? })
+const areModulesRegistered = useAreModulesRegistered()
 ```
-
-### Parameters
-
-- `options`: An optional object literal of options:
-    - `interval`: The interval in milliseconds at which the hook is validating if the registration process is completed.
 
 ### Returns
 


### PR DESCRIPTION
Forgot to add the changeset file for https://github.com/gsoft-inc/wl-squide/pull/127 and noticed I haven't updated the docs to remove the `interval` option from the hook (which is not used anymore because there's no more `setInterval` anymore)