### PR TITLE
Chore: Update webpack configs to remove chunk hashes

### DIFF
--- a/.changeset/silent-clocks-flash.md
+++ b/.changeset/silent-clocks-flash.md
@@ -1,0 +1,6 @@
+---
+"@squide/firefly-configs": patch
+"@squide/webpack-configs": patch
+---
+
+update webpack config dependency to remove hashes from chunk filenames

--- a/packages/firefly-configs/package.json
+++ b/packages/firefly-configs/package.json
@@ -56,7 +56,7 @@
     },
     "dependencies": {
         "@squide/webpack-configs": "workspace:*",
-        "@workleap/webpack-configs": "1.5.0"
+        "@workleap/webpack-configs": "1.5.1"
     },
     "engines": {
         "node": ">=20.0.0"

--- a/packages/webpack-configs/package.json
+++ b/packages/webpack-configs/package.json
@@ -55,7 +55,7 @@
         "webpack": "5.90.3"
     },
     "dependencies": {
-        "@workleap/webpack-configs": "1.5.0",
+        "@workleap/webpack-configs": "1.5.1",
         "deepmerge": "4.3.1",
         "html-webpack-plugin": "5.6.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,8 +210,8 @@ importers:
         specifier: '*'
         version: 0.5.6
       '@workleap/webpack-configs':
-        specifier: 1.5.0
-        version: 1.5.0(@swc/core@1.4.7)(@swc/helpers@0.5.6)(browserslist@4.23.0)(esbuild@0.19.12)(postcss@8.4.38)(typescript@5.4.2)(webpack-dev-server@5.0.3)(webpack@5.90.3)
+        specifier: 1.5.1
+        version: 1.5.1(@swc/core@1.4.7)(@swc/helpers@0.5.6)(browserslist@4.23.0)(esbuild@0.19.12)(postcss@8.4.38)(typescript@5.4.2)(webpack-dev-server@5.0.3)(webpack@5.90.3)
       browserslist:
         specifier: '*'
         version: 4.23.0
@@ -439,8 +439,8 @@ importers:
         specifier: '*'
         version: 0.5.6
       '@workleap/webpack-configs':
-        specifier: 1.5.0
-        version: 1.5.0(@swc/core@1.4.7)(@swc/helpers@0.5.6)(browserslist@4.23.0)(esbuild@0.19.12)(postcss@8.4.38)(typescript@5.4.2)(webpack-dev-server@5.0.3)(webpack@5.90.3)
+        specifier: 1.5.1
+        version: 1.5.1(@swc/core@1.4.7)(@swc/helpers@0.5.6)(browserslist@4.23.0)(esbuild@0.19.12)(postcss@8.4.38)(typescript@5.4.2)(webpack-dev-server@5.0.3)(webpack@5.90.3)
       browserslist:
         specifier: '*'
         version: 4.23.0
@@ -1817,7 +1817,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.24.0
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.1(@babel/core@7.24.3):
     resolution: {integrity: sha512-y4HqEnkelJIOQGd+3g1bTeKsA5c6qM7eOn7VggGVbBc0y8MLSKHacwcIE2PplNlQSj0PqS9rrXL/nkPVK+kUNg==}
@@ -2818,6 +2818,7 @@ packages:
       '@babel/helper-string-parser': 7.24.1
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.24.0:
     resolution: {integrity: sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==}
@@ -4342,7 +4343,7 @@ packages:
       find-up: 6.3.0
       minimatch: 9.0.3
       read-pkg: 7.1.0
-      semver: 7.5.4
+      semver: 7.6.0
       yaml: 2.4.1
       yargs: 17.7.2
     dev: true
@@ -4406,7 +4407,7 @@ packages:
       resolve: 2.0.0-next.5
       rfdc: 1.3.1
       safe-json-stringify: 1.2.0
-      semver: 7.5.4
+      semver: 7.6.0
       string-width: 5.1.2
       strip-ansi: 7.1.0
       supports-color: 9.4.0
@@ -4491,7 +4492,7 @@ packages:
       p-retry: 5.1.2
       p-wait-for: 4.1.0
       path-key: 4.0.0
-      semver: 7.5.4
+      semver: 7.6.0
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 9.0.0
@@ -4523,7 +4524,7 @@ packages:
       p-retry: 5.1.2
       p-wait-for: 4.1.0
       path-key: 4.0.0
-      semver: 7.5.4
+      semver: 7.6.0
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 9.0.0
@@ -4545,7 +4546,7 @@ packages:
       p-locate: 6.0.0
       process: 0.11.10
       read-pkg-up: 9.1.0
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /@netlify/functions-utils@5.2.51(supports-color@9.4.0):
@@ -4767,7 +4768,7 @@ packages:
       precinct: 11.0.5(supports-color@9.4.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.5.4
+      semver: 7.6.0
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -4810,7 +4811,7 @@ packages:
       precinct: 11.0.5
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.5.4
+      semver: 7.6.0
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -7051,15 +7052,15 @@ packages:
       typescript: 5.4.2
     dev: true
 
-  /@workleap/webpack-configs@1.5.0(@swc/core@1.4.7)(@swc/helpers@0.5.6)(browserslist@4.23.0)(esbuild@0.19.12)(postcss@8.4.38)(typescript@5.4.2)(webpack-dev-server@5.0.3)(webpack@5.90.3):
-    resolution: {integrity: sha512-26PbPIbujswo7bahwgjOJt8VUwiave+rZfdeVwuzy1APglu0Zcuse5ozxoWmRZn0twDwqOVRXK4RTqp12+8Jfw==}
+  /@workleap/webpack-configs@1.5.1(@swc/core@1.4.7)(@swc/helpers@0.5.6)(browserslist@4.23.0)(esbuild@0.19.12)(postcss@8.4.38)(typescript@5.4.2)(webpack-dev-server@5.0.3)(webpack@5.90.3):
+    resolution: {integrity: sha512-o7jRK3O5yAFGtp2qgT96B/XuWY58P5AG8EKZy533I13dXN9ibS3eoQOV57v04y8TyYzQJe1nC6mJofToJ1s57g==}
     peerDependencies:
       '@swc/core': '*'
       '@swc/helpers': '*'
       browserslist: '*'
       postcss: '*'
       webpack: '>=5.0.0'
-      webpack-dev-server: '>=4.0.0'
+      webpack-dev-server: '>=5.0.0'
     peerDependenciesMeta:
       webpack-dev-server:
         optional: true
@@ -7350,7 +7351,7 @@ packages:
       global-cache-dir: 4.4.0
       is-plain-obj: 4.1.0
       path-exists: 5.0.0
-      semver: 7.5.4
+      semver: 7.6.0
       write-file-atomic: 4.0.2
     dev: true
 
@@ -8646,7 +8647,7 @@ packages:
     resolution: {integrity: sha512-DP3FpjsiDDvnQC1OJBsdOJZPuy7r0o6sepY2T5M3L/d2nrE23O/ErFkEqyY3ngVL1ZhTj/H0pCMNObZGkEOaaQ==}
     engines: {node: '>=12.20.0'}
     dependencies:
-      chalk: 5.2.0
+      chalk: 5.3.0
       filter-obj: 3.0.0
       is-plain-obj: 4.1.0
       jest-validate: 27.5.1
@@ -8656,7 +8657,7 @@ packages:
     resolution: {integrity: sha512-Soe5lerRg3erMRgYC0EC696/8dMCGpBzcQchFfi55Yrkja8F+P7cUt0LVTIg7u5ob5BexLZ/F1kO+ejmv+nq8w==}
     engines: {node: '>=14.18.0'}
     dependencies:
-      chalk: 5.2.0
+      chalk: 5.3.0
       is-plain-obj: 4.1.0
     dev: true
 
@@ -8783,7 +8784,7 @@ packages:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.5.4
+      semver: 7.6.0
       well-known-symbols: 2.0.0
     dev: true
 
@@ -10873,7 +10874,7 @@ packages:
       proxy-addr: 2.0.7
       rfdc: 1.3.1
       secure-json-parse: 2.7.0
-      semver: 7.5.4
+      semver: 7.6.0
       tiny-lru: 11.2.5
     transitivePeerDependencies:
       - supports-color
@@ -10992,6 +10993,7 @@ packages:
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
 
   /filename-reserved-regex@3.0.0:
@@ -11384,7 +11386,7 @@ packages:
     dependencies:
       '@xhmikosr/downloader': 13.0.1
       node-fetch: 3.3.2
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /git-hooks-list@1.0.3:
@@ -13448,7 +13450,7 @@ packages:
       jws: 3.2.2
       lodash: 4.17.21
       ms: 2.1.3
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /jsx-ast-utils@3.3.5:
@@ -13807,7 +13809,7 @@ packages:
       jest-validate: 27.5.1
       map-obj: 5.0.2
       moize: 6.1.6
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /log-symbols@5.1.0:
@@ -15116,7 +15118,7 @@ packages:
       is-plain-obj: 4.1.0
       normalize-node-version: 12.4.0
       path-exists: 5.0.0
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /nodemon@3.1.0:
@@ -15176,7 +15178,7 @@ packages:
     dependencies:
       all-node-versions: 11.3.0
       filter-obj: 5.1.0
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /normalize-package-data@2.5.0:
@@ -17207,7 +17209,7 @@ packages:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
     engines: {node: '>=12'}
     dependencies:
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /semver@5.7.2:
@@ -17344,7 +17346,7 @@ packages:
       detect-libc: 2.0.3
       node-addon-api: 6.1.0
       prebuild-install: 7.1.2
-      semver: 7.5.4
+      semver: 7.6.0
       simple-get: 4.0.1
       tar-fs: 3.0.5
       tunnel-agent: 0.6.0
@@ -19110,7 +19112,7 @@ packages:
       is-yarn-global: 0.4.1
       latest-version: 7.0.0
       pupa: 3.1.0
-      semver: 7.5.4
+      semver: 7.6.0
       semver-diff: 4.0.0
       xdg-basedir: 5.1.0
     dev: true


### PR DESCRIPTION
This PR updates the @workleap/webpack-config dependencies, which will remove hashes from the chunk file names. This will fix the most common user-experienced errors relating to using the app while a deployment happens.