### PR TITLE
Add transit node for correct cache invalidation on parallel tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,9 @@
     "globalEnv": ["USE_MSW", "ISOLATED", "NETLIFY"],
     "ui": "tui",
     "tasks": {
+        "transit": {
+            "dependsOn": ["^transit"]
+        },
         "dev": {
             "dependsOn": ["@squide/firefly-rsbuild-configs#build", "@squide/firefly-webpack-configs#build"],
             "cache": false,
@@ -35,6 +38,7 @@
             "outputs": ["node_modules/.cache/eslint"]
         },
         "eslint": {
+            "dependsOn": ["transit"],
             "inputs": ["$TURBO_DEFAULT$", "!README.md"],
             "outputs": ["node_modules/.cache/eslint"]
         },
@@ -43,6 +47,7 @@
             "outputs": ["node_modules/.cache/tsbuildinfo.json"]
         },
         "typecheck": {
+            "dependsOn": ["transit"],
             "inputs": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx", "tsconfig.json", "tsconfig.build.json"],
             "outputs": ["node_modules/.cache/tsbuildinfo.json"]
         },


### PR DESCRIPTION
## Summary

- Adds a `transit` task to establish dependency graph relationships for lint/typecheck tasks
- `eslint` and `typecheck` now depend on `transit`, ensuring cache invalidates when dependency source code changes

## Why

Without this, `eslint` and `typecheck` run in parallel (good for speed) but have no dependency relationship to upstream packages. This means changing source code in a dependency won't invalidate the cache for downstream packages' lint/typecheck tasks - leading to stale cache hits.

The `transit` task pattern solves both problems: tasks still run in parallel, but the dependency graph is correctly established for cache invalidation.

## Testing

Run `turbo run lint --dry` to verify the task graph includes transit dependencies.

## AI usage

Chat transcript: https://github.com/workleap/wl-squide/pull/379