### PR TITLE
fix: report failure when pnpm update-outdated-deps fails

### DIFF
--- a/.github/prompts/update-dependencies.md
+++ b/.github/prompts/update-dependencies.md
@@ -20,7 +20,27 @@ Update all dependencies to their latest versions:
 pnpm update-outdated-deps
 ```
 
-Then, check if any `package.json` files were modified:
+**Check the exit code.** If the command failed (non-zero exit code), create an issue reporting the failure and stop:
+
+```bash
+gh issue create \
+  --title "[agent] pnpm update-outdated-deps failed" \
+  --body "## Dependency update command failed
+
+The \`pnpm update-outdated-deps\` command failed before any validation could begin.
+
+## Error
+
+<Paste the full stderr/stdout from the failed command>
+
+## Workflow run
+
+$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+```
+
+Then STOP. You are done.
+
+If the command succeeded, check if any `package.json` files were modified:
 
 ```bash
 git diff --name-only -- '**/package.json' ':!node_modules'


### PR DESCRIPTION
## Summary

- The update-dependencies agent prompt checked `git diff` after running `pnpm update-outdated-deps` but never checked the exit code
- When the command failed (e.g., `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND` in [run #22907258194](https://github.com/workleap/wl-squide/actions/runs/22907258194)), no `package.json` files changed, so the agent silently concluded "no updates" instead of reporting the error
- Now the agent checks the exit code first and creates a GitHub issue if the command fails

## Test plan

- [ ] Trigger the update-dependencies workflow and verify the new behavior on a failure scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)