### PR TITLE
docs: fix initializeFireflyForStorybook reference inaccuracies

### DIFF
--- a/docs/reference/storybook/initializeFireflyForStorybook.md
+++ b/docs/reference/storybook/initializeFireflyForStorybook.md
@@ -30,7 +30,7 @@ const runtime = initializeFireflyForStorybook<TData = unknown>(options?: { local
     - `additionalPlugins`: An optional array with additional plugins to be registered with the runtime.
 ### Returns
 
-A `StorybookRuntime` instance.
+A `Promise` resolving to a `StorybookRuntime` instance.
 
 ## Usage
 
@@ -118,7 +118,7 @@ interface DeferredData {
 }
 
 const registerModule: ModuleRegisterFunction<FireflyRuntime, unknown, DeferredData> = runtime => {
-    return ({ data }) => {
+    return (runtime, data, operation) => {
         if (data.subscription.tier === "enterprise") {
             // Register routes/navigation only available to enterprise tenants.
         }


### PR DESCRIPTION
## Summary
Follow-up to #612 addressing two Copilot review comments:

- The Returns section claimed a direct `StorybookRuntime` instance; the function is `async`, so it actually returns `Promise<StorybookRuntime>`.
- The typed-deferred-data example used `({ data }) => ...` for the deferred registration function. The real signature is positional `(runtime, data, operation) => ...` (see `packages/core/src/registration/registerModule.ts:5` and the codebase example in `agent-docs/design/deferred-registrations.md:22`). The example as published would not compile.

No changeset — docs-only.

## Test plan
- [ ] Docs render correctly in Retype preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)