### PR TITLE
feat(firefly-storybook): allow customizing the decorator's mounted route

### DIFF
--- a/.changeset/customizable-firefly-decorator-route.md
+++ b/.changeset/customizable-firefly-decorator-route.md
@@ -1,0 +1,5 @@
+---
+"@squide/firefly-storybook": minor
+---
+
+Added `route` and `initialEntries` options to `FireflyDecorator` and `withFireflyDecorator` so stories can customize the route mounted under Squide's `RootRoute`. The `route` option (a `RouteObject`, an array of them, or a function receiving the story element) replaces the default `{ path: "/story", element: story }` route, which lets components that read route data — route `handle`s via `useMatches()` and `<Outlet />` children — be storied through the decorator. Existing call sites are unaffected.

--- a/agent-skills/workleap-squide/references/components.md
+++ b/agent-skills/workleap-squide/references/components.md
@@ -260,6 +260,14 @@ const meta = {
 };
 ```
 
+Optional second argument (also `FireflyDecorator` props): `route` customizes the route(s) mounted under `RootRoute` — a `RouteObject`, an array, or a function `({ story }) => ...`, defaulting to `{ path: "/story", element: story }`. Use it to attach a `handle` (read via `useMatches()`) or declare children for an `<Outlet />`. `initialEntries` overrides the in-memory router entries (default `["/story"]`). Note: `registeredRoutes` is not exposed because `StorybookRuntime.registerRoute()` is a no-op, so route registration is always empty.
+
+```tsx
+withFireflyDecorator(runtime, {
+    route: ({ story }) => ({ path: "/story", element: story, handle: { layout: "sidebar" } })
+})
+```
+
 ### withFeatureFlagsOverrideDecorator
 
 Decorator for overriding feature flags in stories. Overrides the initial flag values while the story renders and restores them after.

--- a/docs/reference/storybook/FireflyDecorator.md
+++ b/docs/reference/storybook/FireflyDecorator.md
@@ -19,6 +19,8 @@ Wrap a story with all the required plumbing to render a component using Squide, 
 ### Properties
 
 - `runtime`: A `StorybookRuntime` instance.
+- `route`: The route(s) mounted under Squide's `RootRoute`. A [RouteObject](https://reactrouter.com/start/data/route-object), an array of them, or a function receiving `{ story }`. Defaults to `{ path: "/story", element: story }`. Use it to attach a `handle` or declare children for an [Outlet](https://reactrouter.com/api/components/Outlet).
+- `initialEntries`: The in-memory router initial entries. Defaults to `["/story"]`; match it to a custom `route` `path`.
 
 
 ## Usage

--- a/docs/reference/storybook/withFireflyDecorator.md
+++ b/docs/reference/storybook/withFireflyDecorator.md
@@ -11,12 +11,15 @@ Create a `Decorator` function that returns a [FireflyDecorator](./FireflyDecorat
 ## Reference
 
 ```ts
-const decorator = withFireflyDecorator(runtime)
+const decorator = withFireflyDecorator(runtime, options?)
 ```
 
 ### Parameters
 
 - `runtime`: A `StorybookRuntime` instance.
+- `options`: An optional object literal of options:
+    - `route`: The route(s) mounted under Squide's `RootRoute`. A [RouteObject](https://reactrouter.com/start/data/route-object), an array of them, or a function receiving `{ story }`. Defaults to `{ path: "/story", element: story }`.
+    - `initialEntries`: The in-memory router initial entries. Defaults to `["/story"]`; match it to a custom `route` `path`.
 
 ### Returns
 
@@ -50,4 +53,18 @@ const meta = {
 } satisfies Meta<typeof Page>;
 ```
 
+### Customize the mounted route
 
+Use the `route` option to attach a `handle` (read via [useMatches](https://reactrouter.com/api/hooks/useMatches)) or declare children for an [Outlet](https://reactrouter.com/api/components/Outlet):
+
+```tsx !#5-7
+const meta = {
+    title: "Layout",
+    component: Layout,
+    decorators: [
+        withFireflyDecorator(fireflyRuntime, {
+            route: ({ story }) => ({ path: "/story", element: story, handle: { layout: "sidebar" } })
+        })
+    ]
+};
+```

--- a/packages/firefly-storybook/src/index.ts
+++ b/packages/firefly-storybook/src/index.ts
@@ -1,5 +1,5 @@
 export { initializeFireflyForStorybook, type InitializeFireflyForStorybookOptions } from "./initializeFireflyForStorybook.ts";
 export { StorybookRuntime, StorybookRuntimeScope } from "./StorybookRuntime.ts";
 export { withFeatureFlagsOverrideDecorator } from "./withFeatureFlagsOverrideDecorator.tsx";
-export { FireflyDecorator, withFireflyDecorator, type FireflyDecoratorProps } from "./withFireflyDecorator.tsx";
+export { FireflyDecorator, withFireflyDecorator, type FireflyDecoratorOptions, type FireflyDecoratorProps, type FireflyDecoratorRoute, type FireflyDecoratorRouteArgs } from "./withFireflyDecorator.tsx";
 

--- a/packages/firefly-storybook/src/withFireflyDecorator.tsx
+++ b/packages/firefly-storybook/src/withFireflyDecorator.tsx
@@ -1,48 +1,77 @@
 import { AppRouter, FireflyProvider, FireflyRuntime } from "@squide/firefly";
-import type { PropsWithChildren } from "react";
-import { createMemoryRouter } from "react-router";
+import type { PropsWithChildren, ReactNode } from "react";
+import { createMemoryRouter, type InitialEntry, type RouteObject } from "react-router";
 import { RouterProvider } from "react-router/dom";
 import type { Decorator } from "@storybook/react";
 
-export function withFireflyDecorator(runtime: FireflyRuntime): Decorator {
+export interface FireflyDecoratorRouteArgs {
+    // The Storybook story element to mount.
+    story: ReactNode;
+}
+
+// Describes the route(s) nested under the Squide "RootRoute" element.
+//
+// Provide a "RouteObject" (or an array) to replace the default "{ path: "/story", element: story }" route, or
+// a function receiving the story element to compose the route tree dynamically (e.g. to attach a "handle" or
+// declare children for an "<Outlet />").
+export type FireflyDecoratorRoute =
+    | RouteObject
+    | RouteObject[]
+    | ((args: FireflyDecoratorRouteArgs) => RouteObject | RouteObject[]);
+
+export interface FireflyDecoratorOptions {
+    // Customize the route(s) mounted under the Squide "RootRoute" element. Defaults to "{ path: "/story", element: story }".
+    route?: FireflyDecoratorRoute;
+    // The initial entries for the in-memory router. Defaults to ["/story"]. When providing a "route" with a custom
+    // "path", set "initialEntries" to a matching location, otherwise the router won't match any route.
+    initialEntries?: InitialEntry[];
+}
+
+export function withFireflyDecorator(runtime: FireflyRuntime, options: FireflyDecoratorOptions = {}): Decorator {
+    const {
+        route,
+        initialEntries
+    } = options;
+
     return story => {
         return (
-            <FireflyDecorator runtime={runtime}>
+            <FireflyDecorator runtime={runtime} route={route} initialEntries={initialEntries}>
                 {story()}
             </FireflyDecorator>
         );
     };
 }
 
-export interface FireflyDecoratorProps extends PropsWithChildren {
+export interface FireflyDecoratorProps extends PropsWithChildren, FireflyDecoratorOptions {
     runtime: FireflyRuntime;
 }
 
 export function FireflyDecorator(props: FireflyDecoratorProps) {
     const {
         runtime,
-        children: story
+        children: story,
+        // "story" is destructured first so it can be referenced by this default.
+        route = { path: "/story", element: story },
+        initialEntries = ["/story"]
     } = props;
 
     return (
         <FireflyProvider runtime={runtime}>
             <AppRouter strictMode={false}>
                 {({ rootRoute, routerProps, routerProviderProps }) => {
+                    const storyRoute = typeof route === "function" ? route({ story }) : route;
+                    const childRoutes = Array.isArray(storyRoute) ? storyRoute : [storyRoute];
+
                     return (
                         <RouterProvider
                             router={createMemoryRouter([
                                 {
                                     element: rootRoute,
-                                    children: [
-                                        {
-                                            path: "/story",
-                                            element: story
-                                        }
-                                    ]
+                                    children: childRoutes
                                 }
                             ], {
                                 ...routerProps,
-                                initialEntries: ["/story"]
+                                initialEntries
                             })}
                             {...routerProviderProps}
                         />

--- a/packages/firefly-storybook/tests/withFireflyDecorator.test.tsx
+++ b/packages/firefly-storybook/tests/withFireflyDecorator.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import { NoopLogger } from "@workleap/logging";
+import { Outlet, useMatches } from "react-router";
+import { describe, test } from "vitest";
+import { initializeFireflyForStorybook } from "../src/initializeFireflyForStorybook.ts";
+import { withFireflyDecorator } from "../src/withFireflyDecorator.tsx";
+
+function StoryComponent() {
+    return (
+        <div>story-content</div>
+    );
+}
+
+// Reads the "handle" of the deepest matched route, the scenario from
+// https://github.com/workleap/wl-squide/issues/619.
+function HandleProbe() {
+    const matches = useMatches();
+    const handle = matches[matches.length - 1]?.handle as { layout?: string } | undefined;
+
+    return (
+        <div>layout:{handle?.layout ?? "none"}</div>
+    );
+}
+
+function LayoutWithOutlet() {
+    return (
+        <div>
+            shell-layout
+            <Outlet />
+        </div>
+    );
+}
+
+describe("withFireflyDecorator", () => {
+    test("renders the story at the default \"/story\" route", async ({ expect }) => {
+        const runtime = await initializeFireflyForStorybook({
+            useMsw: false,
+            loggers: [new NoopLogger()]
+        });
+
+        const Decorator = withFireflyDecorator(runtime);
+
+        render(
+            Decorator(
+                () => <StoryComponent />,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                null
+            )
+        );
+
+        expect(await screen.findByText("story-content")).toBeDefined();
+    });
+
+    test("exposes a custom \"handle\" to the story through useMatches", async ({ expect }) => {
+        const runtime = await initializeFireflyForStorybook({
+            useMsw: false,
+            loggers: [new NoopLogger()]
+        });
+
+        const Decorator = withFireflyDecorator(runtime, {
+            route: ({ story }) => ({
+                path: "/story",
+                element: story,
+                handle: { layout: "sidebar" }
+            })
+        });
+
+        render(
+            Decorator(
+                () => <HandleProbe />,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                null
+            )
+        );
+
+        expect(await screen.findByText("layout:sidebar")).toBeDefined();
+    });
+
+    test("renders child routes through an <Outlet /> when the story is a layout", async ({ expect }) => {
+        const runtime = await initializeFireflyForStorybook({
+            useMsw: false,
+            loggers: [new NoopLogger()]
+        });
+
+        const Decorator = withFireflyDecorator(runtime, {
+            route: ({ story }) => ({
+                element: story,
+                children: [
+                    {
+                        index: true,
+                        element: <div>child-page</div>
+                    }
+                ]
+            }),
+            initialEntries: ["/"]
+        });
+
+        render(
+            Decorator(
+                () => <LayoutWithOutlet />,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                null
+            )
+        );
+
+        expect(await screen.findByText("shell-layout")).toBeDefined();
+        expect(await screen.findByText("child-page")).toBeDefined();
+    });
+
+    test("uses a custom \"initialEntries\" to select the mounted route", async ({ expect }) => {
+        const runtime = await initializeFireflyForStorybook({
+            useMsw: false,
+            loggers: [new NoopLogger()]
+        });
+
+        const Decorator = withFireflyDecorator(runtime, {
+            route: ({ story }) => ([
+                {
+                    path: "/foo",
+                    element: <div>foo-page</div>
+                },
+                {
+                    path: "/bar",
+                    element: story
+                }
+            ]),
+            initialEntries: ["/bar"]
+        });
+
+        render(
+            Decorator(
+                () => <StoryComponent />,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                null
+            )
+        );
+
+        expect(await screen.findByText("story-content")).toBeDefined();
+    });
+});

--- a/packages/firefly-storybook/vitest-setup.ts
+++ b/packages/firefly-storybook/vitest-setup.ts
@@ -1,0 +1,6 @@
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+    cleanup();
+});

--- a/packages/firefly-storybook/vitest.config.ts
+++ b/packages/firefly-storybook/vitest.config.ts
@@ -6,7 +6,20 @@ export default defineConfig({
         environment: "happy-dom",
         include: ["tests/**/*.test.{ts,tsx}"],
         exclude: ["node_modules", "dist"],
+        setupFiles: ["./vitest-setup.ts"],
         reporters: "verbose"
+    },
+    resolve: {
+        dedupe: ["react", "react-dom", "react-router"],
+        alias: {
+            // "react-router" and "react-router/dom" are separate entry points that each carry their own copy
+            // of the router context when bundled by Vitest. The decorator imports "RouterProvider" from
+            // "react-router/dom" while "@squide/firefly" reads the context through "react-router" hooks (e.g.
+            // "useLocation" in "RootRoute"), so the two don't match and rendering throws
+            // "useLocation() may be used only in the context of a <Router> component.". Aliasing the subpath to
+            // the main entry (which also exports "RouterProvider") unifies them. Test-only; production bundlers dedupe this.
+            "react-router/dom": "react-router"
+        }
     },
     cacheDir: "./node_modules/.cache/vitest",
     plugins: [react()]


### PR DESCRIPTION
## Summary

Adds `route` and `initialEntries` options to `FireflyDecorator` / `withFireflyDecorator` so stories can customize the route mounted under Squide's `RootRoute`. This unblocks storying components that read route data — route `handle`s via `useMatches()` and `<Outlet />` children — which previously fell into the "no handle / empty Outlet" branch because the decorator hardcoded a childless `/story` route.

The decorator keeps owning `FireflyProvider` / `AppRouter` / `RouterProvider` / `RootRoute` (the parts that are easy to get wrong); only the route subtree under `RootRoute` is now parameterizable.

```tsx
withFireflyDecorator(runtime, {
    route: ({ story }) => ({ path: "/story", element: story, handle: { layout: "sidebar" } })
})
```

## API

- `route?: RouteObject | RouteObject[] | (({ story }) => RouteObject | RouteObject[])` — replaces the default `{ path: "/story", element: story }`.
- `initialEntries?: InitialEntry[]` — defaults to `["/story"]`.

Both are exposed on `withFireflyDecorator(runtime, options?)` and as `FireflyDecorator` props. Existing call sites are unaffected (defaults preserved).

## Note on the issue's option B (`registeredRoutes`)

`registeredRoutes` is intentionally **not** exposed in the callback args. `StorybookRuntime.registerRoute()` is a deliberate no-op, so `useRoutes()` — and therefore `AppRouter`'s `registeredRoutes` — is always empty under a `StorybookRuntime`. Exposing it would be a dead, misleading value. Mounting real registered module routes would require a separate decision to make `StorybookRuntime` register routes; left out of scope here. Callers can still compose any routes explicitly via `route`.

## Tests / verification

- New `tests/withFireflyDecorator.test.tsx`: default mount, `handle` via `useMatches()`, `<Outlet />` children, custom `initialEntries`.
- Added a `vitest-setup.ts` (`afterEach(cleanup)`) and a test-only `react-router/dom` → `react-router` alias + dedupe in `vitest.config.ts` to avoid the dual react-router-instance `useLocation` invariant in the Vitest bundle (production bundlers dedupe this).
- Tests 19/19 · typecheck · eslint · rslib build — all green.

## Docs

- Updated `docs/reference/storybook/{FireflyDecorator,withFireflyDecorator}.md`.
- Updated the `workleap-squide` agent skill (`references/components.md`).
- Added a `minor` changeset.

Addresses #619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
