### PR TITLE
feat(i18next): make useCurrentLanguage reactive

### DIFF
--- a/.changeset/reactive-use-current-language.md
+++ b/.changeset/reactive-use-current-language.md
@@ -1,0 +1,7 @@
+---
+"@squide/i18next": minor
+---
+
+The `useCurrentLanguage` hook is now reactive: components re-render when the language is changed with `useChangeLanguage` or the plugin's `changeLanguage` method. Previously the hook was a one-time read, so consumers that don't render through `useTranslation` (e.g. React Aria's `I18nProvider`, `document.documentElement.lang`) went stale after a runtime language switch.
+
+The `i18nextPlugin` class also exposes new `registerLanguageChangedListener` and `removeLanguageChangedListener` methods.

--- a/docs/reference/i18next/i18nextPlugin.md
+++ b/docs/reference/i18next/i18nextPlugin.md
@@ -124,6 +124,23 @@ const plugin = runtime.getPlugin(i18nextPluginName) as i18nextPlugin;
 plugin.changeLanguage("fr-CA");
 ```
 
+### Listen for language changes
+
+```ts !#9,12
+import { i18nextPlugin } from "@squide/i18next";
+
+const plugin = runtime.getPlugin(i18nextPluginName) as i18nextPlugin;
+
+const listener = () => {
+    console.log("The language changed to", plugin.currentLanguage);
+};
+
+plugin.registerLanguageChangedListener(listener);
+
+// When the listener is not needed anymore.
+plugin.removeLanguageChangedListener(listener);
+```
+
 ### Change the language detection order
 
 By default, the detection of the user's language is done first from the specified URL querystring parameter (`?language` in this example), then from the user's [navigator language settings](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/language). The detection order can be changed by specifying a new value for the [order](https://github.com/i18next/i18next-browser-languageDetector#detector-options) detection option:

--- a/docs/reference/i18next/useCurrentLanguage.md
+++ b/docs/reference/i18next/useCurrentLanguage.md
@@ -6,7 +6,7 @@ toc:
 
 # useCurrentLanguage
 
-Retrieve the current language of the [i18nextPlugin](./i18nextPlugin.md) instance.
+Retrieve the current language of the [i18nextPlugin](./i18nextPlugin.md) instance. This hook is reactive: the component re-renders whenever the language is changed with [useChangeLanguage](./useChangeLanguage.md) or the plugin's `changeLanguage` method.
 
 ## Reference
 

--- a/packages/i18next/src/i18nextPlugin.ts
+++ b/packages/i18next/src/i18nextPlugin.ts
@@ -33,6 +33,8 @@ export function findSupportedPreferredLanguage<T extends string>(userPreferredLa
     return result;
 }
 
+export type LanguageChangedListener = () => void;
+
 export class i18nextPlugin<T extends string = string> extends Plugin {
     #currentLanguage?: T;
 
@@ -40,6 +42,7 @@ export class i18nextPlugin<T extends string = string> extends Plugin {
     readonly #fallbackLanguage: T;
     readonly #languageDetector: LanguageDetector;
     readonly #registry = new i18nextInstanceRegistry();
+    readonly #languageChangedListeners = new Set<LanguageChangedListener>();
 
     constructor(runtime: Runtime, supportedLanguages: T[], fallbackLanguage: T, queryStringKey: string, { detection }: i18nextPluginOptions = {}) {
         super(i18nextPluginName, runtime);
@@ -122,7 +125,19 @@ export class i18nextPlugin<T extends string = string> extends Plugin {
             this.#currentLanguage = language;
 
             this._runtime.logger.information(`[squide] The language has been changed to "${this.#currentLanguage}".`);
+
+            this.#languageChangedListeners.forEach(x => {
+                x();
+            });
         }
+    }
+
+    registerLanguageChangedListener(callback: LanguageChangedListener) {
+        this.#languageChangedListeners.add(callback);
+    }
+
+    removeLanguageChangedListener(callback: LanguageChangedListener) {
+        this.#languageChangedListeners.delete(callback);
     }
 }
 

--- a/packages/i18next/src/index.ts
+++ b/packages/i18next/src/index.ts
@@ -1,6 +1,6 @@
 export { i18nextInstanceRegistry } from "./i18nextInstanceRegistry.ts";
 export { I18nextNavigationItemLabel, type I18nextNavigationItemLabelProps } from "./I18nextNavigationItemLabel.tsx";
-export { findSupportedPreferredLanguage, getI18nextPlugin, i18nextPlugin, i18nextPluginName, type i18nextPluginOptions } from "./i18nextPlugin.ts";
+export { findSupportedPreferredLanguage, getI18nextPlugin, i18nextPlugin, i18nextPluginName, type i18nextPluginOptions, type LanguageChangedListener } from "./i18nextPlugin.ts";
 export { useChangeLanguage } from "./useChangeLanguage.ts";
 export { useCurrentLanguage } from "./useCurrentLanguage.ts";
 export { useI18nextInstance } from "./useI18nextInstance.ts";

--- a/packages/i18next/src/useCurrentLanguage.ts
+++ b/packages/i18next/src/useCurrentLanguage.ts
@@ -1,7 +1,16 @@
+import { useCallback, useSyncExternalStore } from "react";
 import { useI18nextPlugin } from "./useI18nextPlugin.ts";
 
 export function useCurrentLanguage() {
     const plugin = useI18nextPlugin();
 
-    return plugin.currentLanguage;
+    const subscribe = useCallback((callback: () => void) => {
+        plugin.registerLanguageChangedListener(callback);
+
+        return () => {
+            plugin.removeLanguageChangedListener(callback);
+        };
+    }, [plugin]);
+
+    return useSyncExternalStore(subscribe, () => plugin.currentLanguage);
 }

--- a/packages/i18next/tests/i18nextPlugin.test.ts
+++ b/packages/i18next/tests/i18nextPlugin.test.ts
@@ -1,0 +1,79 @@
+import { Runtime } from "@squide/core";
+import { test, vi } from "vitest";
+import { i18nextPlugin } from "../src/i18nextPlugin.ts";
+
+class DummyRuntime extends Runtime {
+    registerRoute() {
+        throw new Error("Method not implemented.");
+    }
+
+    registerPublicRoute() {
+        throw new Error("Method not implemented.");
+    }
+
+    get routes() {
+        return [];
+    }
+
+    registerNavigationItem() {
+        throw new Error("Method not implemented.");
+    }
+
+    getNavigationItems() {
+        return [];
+    }
+
+    getNavigationItemsByMenu() {
+        return new Map();
+    }
+
+    startDeferredRegistrationScope(): void {
+    }
+
+    completeDeferredRegistrationScope(): void {
+    }
+
+    startScope(): Runtime {
+        return new DummyRuntime();
+    }
+
+    _validateRegistrations(): void {
+        throw new Error("Method not implemented.");
+    }
+}
+
+test.concurrent("when the language is changed, the registered language changed listeners are called", ({ expect }) => {
+    const plugin = new i18nextPlugin(new DummyRuntime(), ["en-US", "fr-CA"], "en-US", "language");
+
+    const listener = vi.fn();
+
+    plugin.registerLanguageChangedListener(listener);
+    plugin.changeLanguage("fr-CA");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+});
+
+test.concurrent("when the language is changed to the current language, the registered language changed listeners are not called", ({ expect }) => {
+    const plugin = new i18nextPlugin(new DummyRuntime(), ["en-US", "fr-CA"], "en-US", "language");
+
+    plugin.changeLanguage("fr-CA");
+
+    const listener = vi.fn();
+
+    plugin.registerLanguageChangedListener(listener);
+    plugin.changeLanguage("fr-CA");
+
+    expect(listener).not.toHaveBeenCalled();
+});
+
+test.concurrent("when a language changed listener is removed, it is not called anymore", ({ expect }) => {
+    const plugin = new i18nextPlugin(new DummyRuntime(), ["en-US", "fr-CA"], "en-US", "language");
+
+    const listener = vi.fn();
+
+    plugin.registerLanguageChangedListener(listener);
+    plugin.removeLanguageChangedListener(listener);
+    plugin.changeLanguage("fr-CA");
+
+    expect(listener).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Problem

`useCurrentLanguage` is a one-time read of `i18nextPlugin.currentLanguage` (a plain field). A component calling it never re-renders when the language changes at runtime, so any consumer that doesn't render through `useTranslation` goes stale after `changeLanguage` — e.g. React Aria's `<I18nProvider locale={...}>` or syncing `document.documentElement.lang` (WCAG 3.1.1). This is invisible in apps that only set the language at bootstrap, but breaks apps with a runtime language toggle.

## Change

- `i18nextPlugin` gains `registerLanguageChangedListener` / `removeLanguageChangedListener` (mirroring the `registerStatusChangedListener` convention) and notifies listeners from `changeLanguage` when the language actually changes.
- `useCurrentLanguage` subscribes through `useSyncExternalStore` (same pattern as `useStrictRegistrationMode`). Same signature and return value — callers just become reactive.
- New `LanguageChangedListener` type exported.
- Docs: `useCurrentLanguage.md` states the hook is reactive; `i18nextPlugin.md` gains a "Listen for language changes" section.
- Tests: plugin-level coverage for notify / no-notify-on-same-language / listener removal.
- Changeset: minor bump of `@squide/i18next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)