### PR TITLE
chore(i18next): address Copilot review comments from #626

### DIFF
--- a/docs/reference/i18next/i18nextPlugin.md
+++ b/docs/reference/i18next/i18nextPlugin.md
@@ -116,7 +116,7 @@ const language = plugin.currentLanguage;
 ### Change the current language
 
 ```ts !#6
-import { i18nextPlugin } from "@squide/i18next";
+import { i18nextPlugin, i18nextPluginName } from "@squide/i18next";
 
 const plugin = runtime.getPlugin(i18nextPluginName) as i18nextPlugin;
 
@@ -127,7 +127,7 @@ plugin.changeLanguage("fr-CA");
 ### Listen for language changes
 
 ```ts !#9,12
-import { i18nextPlugin } from "@squide/i18next";
+import { i18nextPlugin, i18nextPluginName } from "@squide/i18next";
 
 const plugin = runtime.getPlugin(i18nextPluginName) as i18nextPlugin;
 

--- a/packages/i18next/package.json
+++ b/packages/i18next/package.json
@@ -52,7 +52,7 @@
         "@typescript-eslint/parser": "8.59.3",
         "@typescript/native-preview": "7.0.0-dev.20260512.1",
         "@workleap/eslint-configs": "2.0.3",
-        "@workleap/logging": "^1.3.8",
+        "@workleap/logging": "1.3.8",
         "@workleap/rslib-configs": "1.2.0",
         "@workleap/typescript-configs": "4.0.2",
         "eslint": "9.39.2",

--- a/packages/i18next/package.json
+++ b/packages/i18next/package.json
@@ -52,6 +52,7 @@
         "@typescript-eslint/parser": "8.59.3",
         "@typescript/native-preview": "7.0.0-dev.20260512.1",
         "@workleap/eslint-configs": "2.0.3",
+        "@workleap/logging": "^1.3.8",
         "@workleap/rslib-configs": "1.2.0",
         "@workleap/typescript-configs": "4.0.2",
         "eslint": "9.39.2",

--- a/packages/i18next/tests/i18nextPlugin.test.ts
+++ b/packages/i18next/tests/i18nextPlugin.test.ts
@@ -1,4 +1,5 @@
 import { Runtime } from "@squide/core";
+import { NoopLogger } from "@workleap/logging";
 import { test, vi } from "vitest";
 import { i18nextPlugin } from "../src/i18nextPlugin.ts";
 
@@ -31,6 +32,10 @@ class DummyRuntime extends Runtime {
     }
 
     completeDeferredRegistrationScope(): void {
+    }
+
+    get logger() {
+        return new NoopLogger();
     }
 
     startScope(): Runtime {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,7 +717,7 @@ importers:
         specifier: 2.0.3
         version: 2.0.3(@eslint/js@9.39.2)(@types/estree@1.0.9)(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)))
       '@workleap/logging':
-        specifier: ^1.3.8
+        specifier: 1.3.8
         version: 1.3.8
       '@workleap/rslib-configs':
         specifier: 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,9 @@ importers:
       '@workleap/eslint-configs':
         specifier: 2.0.3
         version: 2.0.3(@eslint/js@9.39.2)(@types/estree@1.0.9)(@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(@typescript-eslint/parser@8.59.3(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))(jsonc-eslint-parser@3.1.0)(storybook@10.3.6(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(typescript@6.0.3)(vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.7.0)(happy-dom@20.9.0)(msw@2.14.6(@types/node@25.7.0)(typescript@6.0.3))(vite@8.0.12(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)))
+      '@workleap/logging':
+        specifier: ^1.3.8
+        version: 1.3.8
       '@workleap/rslib-configs':
         specifier: 1.2.0
         version: 1.2.0(@rsbuild/core@2.0.5(@module-federation/runtime-tools@2.4.0(node-fetch@3.3.2))(core-js@3.49.0))(@rslib/core@0.21.4(@module-federation/runtime-tools@2.4.0(node-fetch@3.3.2))(@typescript/native-preview@7.0.0-dev.20260512.1)(core-js@3.49.0)(typescript@6.0.3))(@rspack/core@2.0.3(@module-federation/runtime-tools@2.4.0(node-fetch@3.3.2))(@swc/helpers@0.5.21))(typescript@6.0.3)


### PR DESCRIPTION
Follow-up to #626, addressing the Copilot review comments that landed after merge.

- **Docs** — two `i18nextPlugin.md` snippets used `i18nextPluginName` without importing it: the new *Listen for language changes* section from #626, and the pre-existing *Change the current language* section (same bug, predates #626). Both now import it, matching the doc's other four snippets.
- **Tests** — `DummyRuntime` in `i18nextPlugin.test.ts` now overrides `get logger()` with a `NoopLogger` (the same pattern as `packages/core`'s tests). Without it, `createCompositeLogger(true, [])` installs a `BrowserConsoleLogger`, so `changeLanguage` wrote `[squide]` info lines to the console during test runs. `@workleap/logging` is added as a devDependency (test-only usage — it stays out of the published dependency tree).

No changeset: docs and tests only, nothing published changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)